### PR TITLE
[REMOVE] The `kotlinter` for now. I will be using CLI to format code

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-#      - name: Run Linter
-#        run: ./gradlew lintKotlin --parallel --daemon
-
       - name: Run test
         run: ./gradlew testDebugUnitTest --parallel --daemon
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ An Android App template that is preconfigured with Circuit UDF architecture.
 ## What do you get in this template? 📜
 * ✔️ [Circuit](https://github.com/slackhq/circuit) library setup for the app
 * ✔️ Dependency Injection for all Circuit Screens & Presenter combo
-* ✔️ Ktlint task in Gradle
 * ✔️ GitHub Actions for CI
 * ✔️ [Google font](https://github.com/hossain-khan/android-compose-app-template/blob/main/app/src/main/java/app/example/ui/theme/Type.kt#L9-L14) for choosing different app font.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,10 +6,6 @@ plugins {
     alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.ksp)
     alias(libs.plugins.anvil)
-    // Disabled until following is resolved:
-    // - https://github.com/jeremymailen/kotlinter-gradle/issues/414
-    // - https://github.com/pinterest/ktlint/issues/2882
-    //alias(libs.plugins.kotlinter)
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,8 +28,4 @@ plugins {
     // Project: https://github.com/square/anvil
     // Also see: https://github.com/ZacSweers/anvil/blob/main/FORK.md
     alias(libs.plugins.anvil) apply false
-
-    // Applies the Kotlinter plugin for linting Kotlin code.
-    // Project: https://github.com/jeremymailen/kotlinter-gradle
-//    alias(libs.plugins.kotlinter) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,9 +24,6 @@ anvil = "0.4.0"
 # https://dagger.dev/dev-guide/ksp
 dagger = "2.52"
 
-# https://github.com/jeremymailen/kotlinter-gradle
-kotlinter = "4.5.0"
-
 # https://developer.android.com/develop/ui/compose/text/fonts
 googleFonts = "1.7.5"
 
@@ -86,6 +83,4 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp"}
 # https://github.com/ZacSweers/anvil/blob/main/FORK.md
 anvil = { id = "dev.zacsweers.anvil", version.ref = "anvil" }
 
-# https://github.com/jeremymailen/kotlinter-gradle
-kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }
 


### PR DESCRIPTION
Use https://github.com/pinterest/ktlint?tab=readme-ov-file#quick-start brew method instead.

This pull request includes several changes primarily focused on removing the `Ktlint` linter configuration from the project. The most important changes include the removal of `Ktlint` tasks from the Gradle configuration, updates to the `README.md` file, and modifications to the GitHub Actions workflow.

Removal of `Ktlint` configuration:

* [`.github/workflows/android.yml`](diffhunk://#diff-b46b6cdc887427355980140454172d7b5ff3dd1f68523667bdd4947358d927d8L33-L35): Removed the commented-out `Run Linter` step from the GitHub Actions workflow.
* [`app/build.gradle.kts`](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L9-L12): Removed the commented-out `kotlinter` plugin configuration.
* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL27-L29): Removed the `kotlinter` version definition and plugin configuration. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL27-L29) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL89-L90)

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11): Removed the mention of the `Ktlint` task from the list of features provided by the template.