### PR TITLE
[MINOR] Fix order of `enableEdgeToEdge()`

### DIFF
--- a/app/src/main/java/app/example/MainActivity.kt
+++ b/app/src/main/java/app/example/MainActivity.kt
@@ -26,8 +26,8 @@ class MainActivity
         private val circuit: Circuit,
     ) : ComponentActivity() {
         override fun onCreate(savedInstanceState: Bundle?) {
-            super.onCreate(savedInstanceState)
             enableEdgeToEdge()
+            super.onCreate(savedInstanceState)
 
             setContent {
                 ComposeAppTheme {


### PR DESCRIPTION
Based on doc, should be called before `super.onCreate(savedInstanceState)`