### PR TITLE
Fixed lint warning for Activity default constructor

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,14 @@ android {
         compose = true
         buildConfig = true
     }
+
+    lint {
+        // Disable Instantiatable lint rule because we use a custom AppComponentFactory
+        // (ComposeAppComponentFactory) for dependency injection. Activities are injected
+        // via constructor parameters and instantiated by our DI framework (Metro) rather
+        // than the Android system's default no-arg constructor mechanism.
+        disable += "Instantiatable"
+    }
 }
 
 dependencies {

--- a/app/src/main/java/app/example/di/ComposeAppComponentFactory.kt
+++ b/app/src/main/java/app/example/di/ComposeAppComponentFactory.kt
@@ -25,6 +25,9 @@ import kotlin.reflect.KClass
  *     android:appComponentFactory=".di.ComposeAppComponentFactory"
  *     ... />
  * ```
+ *
+ * See official example at:
+ * - https://github.com/ZacSweers/metro/blob/main/samples/compose-navigation-app/src/main/kotlin/dev/zacsweers/metro/sample/androidviewmodel/components/MetroAppComponentFactory.kt
  */
 @Keep
 class ComposeAppComponentFactory : AppComponentFactory() {


### PR DESCRIPTION
Fixes

```
> Task :app:lintReportDebug
Wrote HTML report to file:///home/runner/work/android-compose-app-template/android-compose-app-template/app/build/reports/lint-results-debug.html
Lint found 1 error and 43 warnings. First failure:
/home/runner/work/android-compose-app-template/android-compose-app-template/app/src/main/AndroidManifest.xml:20: Error: This class should provide a default constructor (a public constructor with no arguments) (app.example.MainActivity) [Instantiatable]
            android:name=".MainActivity"
                          ~~~~~~~~~~~~~


> Task :app:lintDebug FAILED
Lint found 1 error, 43 warnings. First failure:

/home/runner/work/android-compose-app-template/android-compose-app-template/app/src/main/AndroidManifest.xml:20: Error: This class should provide a default constructor (a public constructor with no arguments) (app.example.MainActivity) [Instantiatable]
            android:name=".MainActivity"
                          ~~~~~~~~~~~~~

   Explanation for issues of type "Instantiatable":
   Activities, services, broadcast receivers etc. registered in the manifest
   file (or for custom views, in a layout file) must be "instantiatable" by
   the system, which means that the class must be public, it must have an
   empty public constructor, and if it's an inner class, it must be a static
   inner class.

   If you use a custom AppComponentFactory to instantiate app components
   yourself, consider disabling this Lint issue in order to avoid false
   positives.

```