### PR TITLE
[FIXED] Gradle warning for jvmTarget

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,10 +46,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildFeatures {
         compose = true
         buildConfig = true
@@ -61,6 +57,13 @@ android {
         // via constructor parameters and instantiated by our DI framework (Metro) rather
         // than the Android system's default no-arg constructor mechanism.
         disable += "Instantiatable"
+    }
+}
+
+kotlin {
+    // See https://kotlinlang.org/docs/gradle-compiler-options.html
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 


### PR DESCRIPTION
Fixes

```
> Configure project :app
w: file:///Users/hossain/dev/repos/hk-projects/android-compose-app-template/app/build.gradle.kts:50:9: 'jvmTarget: String' is deprecated. Please migrate to the compilerOptions DSL. More details are here: https://kotl.in/u1r8ln

```