### PR TITLE
[FIXED] Setup script

### DIFF
--- a/setup-project.sh
+++ b/setup-project.sh
@@ -105,7 +105,7 @@ do
       cp -r $n/java/app/example/* $n/java/$SUBDIR/ 2>/dev/null || true
       # Also handle the case where there are hidden files
       cp -r $n/java/app/example/.[^.]* $n/java/$SUBDIR/ 2>/dev/null || true
-      echo "Successfully moved $(find $n/java/$SUBDIR -type f | wc -l | tr -d ' ') files"
+      echo "Successfully copied $(find $n/java/$SUBDIR -type f | wc -l | tr -d ' ') files"
     else
       echo "No files found in $n/java/app/example to move."
     fi


### PR DESCRIPTION
Fixes https://github.com/hossain-khan/android-compose-app-template/issues/143

## Summary of Fixes Applied to setup-project.sh

I identified and fixed two major issues in the script:

### 1. **Flag Parsing Issue**
**Problem**: The original script used a `while` loop that stopped processing flags when it encountered the first positional argument. This meant that when you ran:
```bash
./setup-project.sh dev.hossain.gphotos MyPhotos --keep-workmanager --keep-examples
```
The script would see `dev.hossain.gphotos` as the first non-flag argument and stop processing the flags that came after `MyPhotos`.

**Solution**: I changed the argument parsing logic to collect all positional arguments in an array while processing flags anywhere in the argument list:

```bash
POSITIONAL_ARGS=()

while [[ $# -gt 0 ]]; do
  case $1 in
    --keep-examples|--keep-workmanager|--keep-script)
      # Set flag and continue
      ;;
    *)
      POSITIONAL_ARGS+=("$1")  # Collect positional args
      ;;
  esac
done

PACKAGE="${POSITIONAL_ARGS[0]}"
APPNAME="${POSITIONAL_ARGS[1]}"
```

### 2. **Directory Structure Issue**
**Problem**: The original script used `find ... -exec mv {} $target/ \;` which moved all files to the root of the target directory, destroying the subdirectory structure. Files from `app/example/ui/theme/`, `app/example/di/`, etc. were all moved to the same flat directory.

**Solution**: I replaced the `mv` command with `cp -r` to preserve directory structure:

```bash
# Old (flattening structure):
find $n/java/app/example -type f -exec mv {} $n/java/$SUBDIR/ \;

# New (preserving structure):
cp -r $n/java/app/example/* $n/java/$SUBDIR/ 2>/dev/null || true
```

### 3. **Additional Improvements**
- Added better feedback showing how many files were moved
- Added an example in usage showing multiple flags
- Added error handling for the copy operations

## Test Results

After applying these fixes, running:
```bash
./setup-project.sh dev.hossain.gphotos MyPhotos --keep-workmanager --keep-examples --keep-script
```

Now correctly:
- ✅ Parses flags properly (`Keep examples: true`, `Keep WorkManager: true`, `Keep script: true`)
- ✅ Preserves directory structure (`ui/theme/`, `di/`, `circuit/`, `work/`, `data/`)
- ✅ Keeps Example files when requested
- ✅ Keeps WorkManager files when requested
- ✅ Keeps the script itself when requested

The script now works as intended and handles flag positioning flexibly while maintaining the proper package directory structure.