### PR TITLE
[UPDATE] Setup script docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ An Android App template that is preconfigured with ⚡️ Circuit UDF architectu
 ## Recent Improvements 🚀
 * ✔️ **Flexible flag positioning** - Put flags before or after positional arguments 
 * ✔️ **Directory structure preservation** - Maintains `ui/theme/`, `di/`, `circuit/`, `work/`, `data/` subdirectories
+* ✔️ **User-friendly defaults** - Keeps examples and WorkManager by default (use `--remove-*` flags to exclude)
 * ✔️ **Improved error handling** - Better feedback during setup process
 * ✔️ **Enhanced argument parsing** - Handles complex flag combinations correctly
 
@@ -32,22 +33,22 @@ You have **two options** for customizing this template:
 Run the setup script to automatically handle most of the configuration:
 
 ```bash
-# Basic usage - removes examples and WorkManager
+# Basic usage - keeps examples and WorkManager by default
 ./setup-project.sh com.mycompany.appname MyAppName
 
-# Keep examples for reference
-./setup-project.sh com.mycompany.appname MyAppName --keep-examples
+# Remove examples if you don't need them
+./setup-project.sh com.mycompany.appname MyAppName --remove-examples
 
-# Keep WorkManager if you need background tasks
-./setup-project.sh com.mycompany.appname MyAppName --keep-workmanager --keep-examples
+# Remove WorkManager if you don't need background tasks
+./setup-project.sh com.mycompany.appname MyAppName --remove-workmanager --remove-examples
 
 # Keep the script for debugging (useful during development)
 ./setup-project.sh com.mycompany.appname MyAppName --keep-script
 
 # Flags can be positioned flexibly - all of these work the same:
-./setup-project.sh --keep-examples com.mycompany.appname MyAppName --keep-workmanager
-./setup-project.sh com.mycompany.appname --keep-examples MyAppName --keep-workmanager
-./setup-project.sh com.mycompany.appname MyAppName --keep-examples --keep-workmanager --keep-script
+./setup-project.sh --remove-examples com.mycompany.appname MyAppName --remove-workmanager
+./setup-project.sh com.mycompany.appname --remove-examples MyAppName --remove-workmanager
+./setup-project.sh com.mycompany.appname MyAppName --remove-examples --remove-workmanager --keep-script
 ```
 
 **What the script does automatically:**
@@ -55,8 +56,8 @@ Run the setup script to automatically handle most of the configuration:
 - **Preserves subdirectory structure** (`ui/theme/`, `di/`, `circuit/`, `work/`, `data/`)
 - Updates app name and package ID in XML and Gradle files
 - Renames `CircuitApp` to `YourAppNameApp`
-- Removes `Example*` files (optional with `--keep-examples`)
-- Removes WorkManager files (optional with `--keep-workmanager`)
+- **Keeps Example* files by default** (use `--remove-examples` to exclude)
+- **Keeps WorkManager files by default** (use `--remove-workmanager` to exclude)
 - Creates a fresh git repository with descriptive initial commit
 - Removes template-specific files
 
@@ -83,12 +84,17 @@ These still need to be done manually after using the script:
 ### Troubleshooting 🔧
 
 **Script shows wrong flag values (Keep examples: false when --keep-examples was passed):**
-- ✅ **Fixed** - Script now properly handles flags in any position
+- ✅ **Fixed** - Script now properly handles flags in any position and defaults to keeping examples/WorkManager
 - Use `--keep-script` to preserve the script for debugging if needed
 
 **Directory structure gets flattened (all files moved to package root):**
 - ✅ **Fixed** - Script now preserves subdirectory structure (`ui/theme/`, `di/`, etc.)
 - Files maintain their original organization within the new package
+
+**Want to remove examples or WorkManager:**
+- Use `--remove-examples` to exclude Example* files  
+- Use `--remove-workmanager` to exclude WorkManager components
+- Both are kept by default for easier project exploration
 
 **Need to re-run the script:**
 - Use `--keep-script` flag to prevent script deletion

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ An Android App template that is preconfigured with ⚡️ Circuit UDF architectu
 * ✔️ [Kotlin formatter](https://github.com/jeremymailen/kotlinter-gradle) plugin for code formatting and linting
 * ✔️ [Work Manager](https://developer.android.com/develop/background-work/background-tasks/persistent) for scheduling background tasks
 
+## Recent Improvements 🚀
+* ✔️ **Flexible flag positioning** - Put flags before or after positional arguments 
+* ✔️ **Directory structure preservation** - Maintains `ui/theme/`, `di/`, `circuit/`, `work/`, `data/` subdirectories
+* ✔️ **Improved error handling** - Better feedback during setup process
+* ✔️ **Enhanced argument parsing** - Handles complex flag combinations correctly
+
 > [!WARNING]  
 > _This template is only for Android app setup. If you are looking for a multi-platform supported template,_
 > _look at the official [Circuit](https://github.com/slackhq/circuit) example apps included in the project repository._
@@ -37,16 +43,21 @@ Run the setup script to automatically handle most of the configuration:
 
 # Keep the script for debugging (useful during development)
 ./setup-project.sh com.mycompany.appname MyAppName --keep-script
+
+# Flags can be positioned flexibly - all of these work the same:
+./setup-project.sh --keep-examples com.mycompany.appname MyAppName --keep-workmanager
+./setup-project.sh com.mycompany.appname --keep-examples MyAppName --keep-workmanager
+./setup-project.sh com.mycompany.appname MyAppName --keep-examples --keep-workmanager --keep-script
 ```
 
 **What the script does automatically:**
 - Renames package from `app.example` to your preferred package name
-- Updates directory structure based on package name
+- **Preserves subdirectory structure** (`ui/theme/`, `di/`, `circuit/`, `work/`, `data/`)
 - Updates app name and package ID in XML and Gradle files
 - Renames `CircuitApp` to `YourAppNameApp`
 - Removes `Example*` files (optional with `--keep-examples`)
 - Removes WorkManager files (optional with `--keep-workmanager`)
-- Creates a fresh git repository
+- Creates a fresh git repository with descriptive initial commit
 - Removes template-specific files
 
 #### Option 2: Manual Customization 🔧
@@ -68,6 +79,21 @@ These still need to be done manually after using the script:
 * [ ] Update/remove repository license
 * [ ] Configure [renovate](https://github.com/apps/renovate) for dependency management or remove [`renovate.json`](https://github.com/hossain-khan/android-compose-app-template/blob/main/renovate.json) file
 * [ ] Choose [Google font](https://github.com/hossain-khan/android-compose-app-template/blob/main/app/src/main/java/app/example/ui/theme/Type.kt#L16-L30) for your app, or remove it.
+
+### Troubleshooting 🔧
+
+**Script shows wrong flag values (Keep examples: false when --keep-examples was passed):**
+- ✅ **Fixed** - Script now properly handles flags in any position
+- Use `--keep-script` to preserve the script for debugging if needed
+
+**Directory structure gets flattened (all files moved to package root):**
+- ✅ **Fixed** - Script now preserves subdirectory structure (`ui/theme/`, `di/`, etc.)
+- Files maintain their original organization within the new package
+
+**Need to re-run the script:**
+- Use `--keep-script` flag to prevent script deletion
+- Restore from git if you have the original template committed
+- Re-clone the template repository if needed
 
 
 ## Demo 📹

--- a/README.md
+++ b/README.md
@@ -14,13 +14,6 @@ An Android App template that is preconfigured with ⚡️ Circuit UDF architectu
 * ✔️ [Kotlin formatter](https://github.com/jeremymailen/kotlinter-gradle) plugin for code formatting and linting
 * ✔️ [Work Manager](https://developer.android.com/develop/background-work/background-tasks/persistent) for scheduling background tasks
 
-## Recent Improvements 🚀
-* ✔️ **Flexible flag positioning** - Put flags before or after positional arguments 
-* ✔️ **Directory structure preservation** - Maintains `ui/theme/`, `di/`, `circuit/`, `work/`, `data/` subdirectories
-* ✔️ **User-friendly defaults** - Keeps examples and WorkManager by default (use `--remove-*` flags to exclude)
-* ✔️ **Improved error handling** - Better feedback during setup process
-* ✔️ **Enhanced argument parsing** - Handles complex flag combinations correctly
-
 > [!WARNING]  
 > _This template is only for Android app setup. If you are looking for a multi-platform supported template,_
 > _look at the official [Circuit](https://github.com/slackhq/circuit) example apps included in the project repository._
@@ -28,6 +21,9 @@ An Android App template that is preconfigured with ⚡️ Circuit UDF architectu
 ### Post-process after cloning 🧑‍🏭
 
 You have **two options** for customizing this template:
+
+<details>
+<summary>Option 1: Automated Customization (Recommended)</summary>
 
 #### Option 1: Automated Customization (Recommended) 🤖
 Run the setup script to automatically handle most of the configuration:
@@ -53,13 +49,18 @@ Run the setup script to automatically handle most of the configuration:
 
 **What the script does automatically:**
 - Renames package from `app.example` to your preferred package name
-- **Preserves subdirectory structure** (`ui/theme/`, `di/`, `circuit/`, `work/`, `data/`)
+- Preserves subdirectory structure (`ui/theme/`, `di/`, `circuit/`, `work/`, `data/`)
 - Updates app name and package ID in XML and Gradle files
 - Renames `CircuitApp` to `YourAppNameApp`
-- **Keeps Example* files by default** (use `--remove-examples` to exclude)
-- **Keeps WorkManager files by default** (use `--remove-workmanager` to exclude)
+- Keeps Example* files by default (use `--remove-examples` to exclude)
+- Keeps WorkManager files by default (use `--remove-workmanager` to exclude)
 - Creates a fresh git repository with descriptive initial commit
 - Removes template-specific files
+
+</details>
+
+<details>
+<summary>Option 2: Manual Customization 🔧</summary>
 
 #### Option 2: Manual Customization 🔧
 If you prefer manual control, complete these tasks:
@@ -71,6 +72,11 @@ If you prefer manual control, complete these tasks:
 * [ ] Remove `Example***` files that were added to showcase example usage of app and Circuit.
 * [ ] Remove WorkManager and Worker example files if you are not using them.
 
+</details>
+
+<details>
+<summary>Additional Manual Steps (Both Options) 📝</summary>
+
 #### Additional Manual Steps (Both Options) 📝
 These still need to be done manually after using the script:
 
@@ -81,25 +87,7 @@ These still need to be done manually after using the script:
 * [ ] Configure [renovate](https://github.com/apps/renovate) for dependency management or remove [`renovate.json`](https://github.com/hossain-khan/android-compose-app-template/blob/main/renovate.json) file
 * [ ] Choose [Google font](https://github.com/hossain-khan/android-compose-app-template/blob/main/app/src/main/java/app/example/ui/theme/Type.kt#L16-L30) for your app, or remove it.
 
-### Troubleshooting 🔧
-
-**Script shows wrong flag values (Keep examples: false when --keep-examples was passed):**
-- ✅ **Fixed** - Script now properly handles flags in any position and defaults to keeping examples/WorkManager
-- Use `--keep-script` to preserve the script for debugging if needed
-
-**Directory structure gets flattened (all files moved to package root):**
-- ✅ **Fixed** - Script now preserves subdirectory structure (`ui/theme/`, `di/`, etc.)
-- Files maintain their original organization within the new package
-
-**Want to remove examples or WorkManager:**
-- Use `--remove-examples` to exclude Example* files  
-- Use `--remove-workmanager` to exclude WorkManager components
-- Both are kept by default for easier project exploration
-
-**Need to re-run the script:**
-- Use `--keep-script` flag to prevent script deletion
-- Restore from git if you have the original template committed
-- Re-clone the template repository if needed
+</details>
 
 
 ## Demo 📹

--- a/setup-project.sh
+++ b/setup-project.sh
@@ -6,6 +6,19 @@
 #
 # Usage: bash setup-project.sh com.mycompany.appname AppName [--keep-examples] [--keep-workmanager] [--keep-script]
 #
+# Examples:
+#   bash setup-project.sh com.mycompany.todoapp TodoApp
+#   bash setup-project.sh com.mycompany.newsapp NewsApp --keep-examples
+#   bash setup-project.sh dev.hossain.gphotos MyPhotos --keep-examples --keep-workmanager
+#   bash setup-project.sh com.example.allapp AllApp --keep-examples --keep-workmanager --keep-script
+#
+# Features:
+#   - Flexible flag positioning (flags can come before or after positional arguments)
+#   - Preserves subdirectory structure (ui/theme, di, circuit, work, data directories)
+#   - Handles package renaming and file/class renaming automatically
+#   - Optional retention of Example files and WorkManager components
+#   - Creates fresh git repository with initial commit
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 #
 
@@ -76,6 +89,9 @@ if [[ ${#POSITIONAL_ARGS[@]} -lt 2 ]]; then
    echo "  --keep-examples     Keep Example* files for reference"
    echo "  --keep-workmanager  Keep WorkManager related files"
    echo "  --keep-script       Keep this setup script (useful for debugging)"
+   echo ""
+   echo "Note: Flags can be positioned anywhere in the command line"
+   echo "      Directory structure (ui/theme, di, circuit, work, data) is preserved"
    exit 2
 fi
 

--- a/setup-project.sh
+++ b/setup-project.sh
@@ -103,8 +103,10 @@ SUBDIR=${PACKAGE//.//} # Replaces . with /
 echo "🚀 Starting Android Circuit App Template customization..."
 echo "📦 New package: $PACKAGE"
 echo "📱 App name: $APPNAME"
-echo "🗂️  Keep examples: $([ "$REMOVE_EXAMPLES" = false ] && echo "true" || echo "false")"
-echo "⚙️  Keep WorkManager: $([ "$REMOVE_WORKMANAGER" = false ] && echo "true" || echo "false")"
+KEEP_EXAMPLES=$([ "$REMOVE_EXAMPLES" = false ] && echo "true" || echo "false")
+KEEP_WORKMANAGER=$([ "$REMOVE_WORKMANAGER" = false ] && echo "true" || echo "false")
+echo "🗂️  Keep examples: $KEEP_EXAMPLES"
+echo "⚙️  Keep WorkManager: $KEEP_WORKMANAGER"
 echo "📜 Keep script: $KEEP_SCRIPT"
 echo ""
 

--- a/setup-project.sh
+++ b/setup-project.sh
@@ -4,19 +4,19 @@
 # Adapted for Circuit + Metro DI architecture
 # Compatible with bash 3.2+ (standard on macOS)
 #
-# Usage: bash setup-project.sh com.mycompany.appname AppName [--keep-examples] [--keep-workmanager] [--keep-script]
+# Usage: bash setup-project.sh com.mycompany.appname AppName [--remove-examples] [--remove-workmanager] [--keep-script]
 #
 # Examples:
 #   bash setup-project.sh com.mycompany.todoapp TodoApp
-#   bash setup-project.sh com.mycompany.newsapp NewsApp --keep-examples
-#   bash setup-project.sh dev.hossain.gphotos MyPhotos --keep-examples --keep-workmanager
-#   bash setup-project.sh com.example.allapp AllApp --keep-examples --keep-workmanager --keep-script
+#   bash setup-project.sh com.mycompany.newsapp NewsApp --remove-examples
+#   bash setup-project.sh dev.hossain.gphotos MyPhotos --remove-examples --remove-workmanager
+#   bash setup-project.sh com.example.allapp AllApp --remove-examples --remove-workmanager --keep-script
 #
 # Features:
 #   - Flexible flag positioning (flags can come before or after positional arguments)
 #   - Preserves subdirectory structure (ui/theme, di, circuit, work, data directories)
 #   - Handles package renaming and file/class renaming automatically
-#   - Optional retention of Example files and WorkManager components
+#   - Keeps Example files and WorkManager components by default (use --remove-* to exclude)
 #   - Creates fresh git repository with initial commit
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,20 +42,20 @@ cleanup_on_error() {
 trap 'cleanup_on_error $LINENO' ERR
 
 # Parse arguments using while loop with shift for proper flag handling
-KEEP_EXAMPLES=false
-KEEP_WORKMANAGER=false
+REMOVE_EXAMPLES=false
+REMOVE_WORKMANAGER=false
 KEEP_SCRIPT=false
 POSITIONAL_ARGS=()
 
 # Process all arguments, collecting positional args and setting flags
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --keep-examples)
-      KEEP_EXAMPLES=true
+    --remove-examples)
+      REMOVE_EXAMPLES=true
       shift
       ;;
-    --keep-workmanager)
-      KEEP_WORKMANAGER=true
+    --remove-workmanager)
+      REMOVE_WORKMANAGER=true
       shift
       ;;
     --keep-script)
@@ -76,22 +76,23 @@ done
 
 # Check if we have enough positional arguments
 if [[ ${#POSITIONAL_ARGS[@]} -lt 2 ]]; then
-   echo "Usage: bash setup-project.sh com.mycompany.appname AppName [--keep-examples] [--keep-workmanager] [--keep-script]" >&2
+   echo "Usage: bash setup-project.sh com.mycompany.appname AppName [--remove-examples] [--remove-workmanager] [--keep-script]" >&2
    echo ""
    echo "Examples:"
    echo "  bash setup-project.sh com.mycompany.todoapp TodoApp"
-   echo "  bash setup-project.sh com.mycompany.newsapp NewsApp --keep-examples"
-   echo "  bash setup-project.sh com.mycompany.taskapp TaskApp --keep-workmanager"
+   echo "  bash setup-project.sh com.mycompany.newsapp NewsApp --remove-examples"
+   echo "  bash setup-project.sh com.mycompany.taskapp TaskApp --remove-workmanager"
    echo "  bash setup-project.sh com.mycompany.debugapp DebugApp --keep-script"
-   echo "  bash setup-project.sh com.mycompany.allapp AllApp --keep-examples --keep-workmanager --keep-script"
+   echo "  bash setup-project.sh com.mycompany.allapp AllApp --remove-examples --remove-workmanager --keep-script"
    echo ""
    echo "Options:"
-   echo "  --keep-examples     Keep Example* files for reference"
-   echo "  --keep-workmanager  Keep WorkManager related files"
+   echo "  --remove-examples   Remove Example* files (kept by default)"
+   echo "  --remove-workmanager Remove WorkManager related files (kept by default)"
    echo "  --keep-script       Keep this setup script (useful for debugging)"
    echo ""
    echo "Note: Flags can be positioned anywhere in the command line"
    echo "      Directory structure (ui/theme, di, circuit, work, data) is preserved"
+   echo "      Examples and WorkManager are kept by default - use --remove-* to exclude"
    exit 2
 fi
 
@@ -102,8 +103,8 @@ SUBDIR=${PACKAGE//.//} # Replaces . with /
 echo "🚀 Starting Android Circuit App Template customization..."
 echo "📦 New package: $PACKAGE"
 echo "📱 App name: $APPNAME"
-echo "🗂️  Keep examples: $KEEP_EXAMPLES"
-echo "⚙️  Keep WorkManager: $KEEP_WORKMANAGER"
+echo "🗂️  Keep examples: $([ "$REMOVE_EXAMPLES" = false ] && echo "true" || echo "false")"
+echo "⚙️  Keep WorkManager: $([ "$REMOVE_WORKMANAGER" = false ] && echo "true" || echo "false")"
 echo "📜 Keep script: $KEEP_SCRIPT"
 echo ""
 
@@ -157,7 +158,7 @@ echo "🏷️  Step 5: Updating app name in XML files..."
 find ./ -name "strings.xml" -exec sed -i.bak "s/<string name=\"app_name\">.*<\/string>/<string name=\"app_name\">$APPNAME<\/string>/g" {} \;
 
 # Step 6: Handle Example files
-if [ "$KEEP_EXAMPLES" = false ]; then
+if [ "$REMOVE_EXAMPLES" = true ]; then
     echo "🗑️  Step 6: Removing Example* files..."
     find ./ -name "Example*.kt" -type f -delete
     find ./ -name "*Example*.kt" -type f -delete
@@ -167,7 +168,7 @@ else
 fi
 
 # Step 7: Handle WorkManager files
-if [ "$KEEP_WORKMANAGER" = false ]; then
+if [ "$REMOVE_WORKMANAGER" = true ]; then
     echo "🗑️  Step 7: Removing WorkManager files..."
     find ./ -path "*/work/*" -name "*.kt" -type f -delete
     find ./ -name "*Worker*.kt" -type f -delete
@@ -258,8 +259,8 @@ if ! git commit -m "Initial commit: $APPNAME
 - Customized from android-compose-app-template
 - Package: $PACKAGE  
 - Circuit + Metro architecture
-- Examples kept: $KEEP_EXAMPLES
-- WorkManager kept: $KEEP_WORKMANAGER"; then
+- Examples kept: $([ "$REMOVE_EXAMPLES" = false ] && echo "true" || echo "false")
+- WorkManager kept: $([ "$REMOVE_WORKMANAGER" = false ] && echo "true" || echo "false")"; then
     echo "❌ Error: Failed to create initial commit."
     exit 1
 fi
@@ -276,10 +277,10 @@ echo "   1. Open the project in Android Studio"
 echo "   2. Update app theme colors"
 echo "   3. Generate your app icon"
 echo "   4. Review and update .editorconfig"
-if [ "$KEEP_EXAMPLES" = true ]; then
+if [ "$REMOVE_EXAMPLES" = false ]; then
     echo "   5. Remove Example* files when you no longer need them"
 fi
-if [ "$KEEP_WORKMANAGER" = false ]; then
+if [ "$REMOVE_WORKMANAGER" = true ]; then
     echo "   5. Add WorkManager back if you need background tasks"
 fi
 echo ""


### PR DESCRIPTION
Fixes https://github.com/hossain-khan/android-compose-app-template/issues/143

This pull request updates the `README.md` documentation and the `setup-project.sh` script to improve clarity and flexibility for users customizing the Android app template. The changes include replacing "keep" flags with "remove" flags for better default behavior, enhancing documentation, and adding flexible flag positioning in the script.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R25-R64): Updated instructions to reflect the new default behavior of keeping examples and WorkManager files unless explicitly removed using `--remove-examples` or `--remove-workmanager`. Added collapsible sections for better organization and readability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R25-R64) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R75-R79) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R90-R91)

### Script Enhancements:
* [`setup-project.sh`](diffhunk://#diff-ae03887783740c86853a2a51863e7ac9e8c116bdc9a968edd41dc0b671cf5966L7-R20): Replaced `--keep-examples` and `--keep-workmanager` flags with `--remove-examples` and `--remove-workmanager` for improved clarity. Updated usage examples and added support for flexible flag positioning. [[1]](diffhunk://#diff-ae03887783740c86853a2a51863e7ac9e8c116bdc9a968edd41dc0b671cf5966L7-R20) [[2]](diffhunk://#diff-ae03887783740c86853a2a51863e7ac9e8c116bdc9a968edd41dc0b671cf5966L32-R58) [[3]](diffhunk://#diff-ae03887783740c86853a2a51863e7ac9e8c116bdc9a968edd41dc0b671cf5966L66-R95)
* [`setup-project.sh`](diffhunk://#diff-ae03887783740c86853a2a51863e7ac9e8c116bdc9a968edd41dc0b671cf5966L144-R161): Modified logic to handle the new "remove" flags, ensuring proper removal of Example files and WorkManager components when specified. [[1]](diffhunk://#diff-ae03887783740c86853a2a51863e7ac9e8c116bdc9a968edd41dc0b671cf5966L144-R161) [[2]](diffhunk://#diff-ae03887783740c86853a2a51863e7ac9e8c116bdc9a968edd41dc0b671cf5966L154-R171)
* [`setup-project.sh`](diffhunk://#diff-ae03887783740c86853a2a51863e7ac9e8c116bdc9a968edd41dc0b671cf5966L89-R107): Updated messages and initial commit details to reflect the new default behavior of keeping examples and WorkManager files. [[1]](diffhunk://#diff-ae03887783740c86853a2a51863e7ac9e8c116bdc9a968edd41dc0b671cf5966L89-R107) [[2]](diffhunk://#diff-ae03887783740c86853a2a51863e7ac9e8c116bdc9a968edd41dc0b671cf5966L245-R263) [[3]](diffhunk://#diff-ae03887783740c86853a2a51863e7ac9e8c116bdc9a968edd41dc0b671cf5966L263-R283)