### PR TITLE
[UPDATE] `composeBom = "2025.09.01"` add local icons

### DIFF
--- a/.github/workflows/test-setup-script.yml
+++ b/.github/workflows/test-setup-script.yml
@@ -139,6 +139,17 @@ jobs:
           
           echo "✅ WorkManager preservation validation passed"
 
+      - name: Validate baseline_* vector drawable icons are deleted
+        run: |
+          cd /tmp/test-workspace/original-template
+          if ls app/src/main/res/drawable/baseline_*.xml 1> /dev/null 2>&1; then
+            echo "❌ baseline_* vector drawable icons still exist!"
+            ls app/src/main/res/drawable/baseline_*.xml
+            exit 1
+          else
+            echo "✅ No baseline_* vector drawable icons found."
+          fi
+
       - name: Test project compilation
         timeout-minutes: 10
         run: |

--- a/.github/workflows/test-setup-script.yml
+++ b/.github/workflows/test-setup-script.yml
@@ -139,17 +139,6 @@ jobs:
           
           echo "✅ WorkManager preservation validation passed"
 
-      - name: Validate baseline_* vector drawable icons are deleted
-        run: |
-          cd /tmp/test-workspace/original-template
-          if ls app/src/main/res/drawable/baseline_*.xml 1> /dev/null 2>&1; then
-            echo "❌ baseline_* vector drawable icons still exist!"
-            ls app/src/main/res/drawable/baseline_*.xml
-            exit 1
-          else
-            echo "✅ No baseline_* vector drawable icons found."
-          fi
-
       - name: Test project compilation
         timeout-minutes: 10
         run: |

--- a/app/src/main/java/app/example/circuit/ExampleEmailDetailsScreen.kt
+++ b/app/src/main/java/app/example/circuit/ExampleEmailDetailsScreen.kt
@@ -20,8 +20,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Button
 import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
@@ -34,9 +32,11 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import app.example.R
 import app.example.data.Email
 import app.example.data.ExampleEmailRepository
 import app.example.data.ExampleEmailValidator
@@ -112,7 +112,7 @@ fun EmailDetailContent(
         Column(modifier.padding(innerPadding).padding(16.dp)) {
             Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                 Image(
-                    Icons.Default.Person,
+                    painter = painterResource(id = R.drawable.baseline_person_24),
                     modifier =
                         Modifier
                             .size(40.dp)
@@ -177,7 +177,7 @@ fun EmailItem(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Image(
-            Icons.Default.Person,
+            painter = painterResource(id = R.drawable.baseline_person_24),
             modifier =
                 Modifier
                     .size(40.dp)

--- a/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
+++ b/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
@@ -13,8 +13,6 @@ import android.util.Log
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -26,6 +24,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import app.example.R
 import app.example.circuit.overlay.AppInfoOverlay
 import app.example.data.Email
 import app.example.data.ExampleAppVersionService
@@ -121,7 +121,7 @@ fun Inbox(
                         },
                     ) {
                         Icon(
-                            imageVector = Icons.Default.Info,
+                            painter = painterResource(id = R.drawable.baseline_info_24),
                             contentDescription = "App Info",
                         )
                     }

--- a/app/src/main/java/app/example/circuit/overlay/AppInfoOverlay.kt
+++ b/app/src/main/java/app/example/circuit/overlay/AppInfoOverlay.kt
@@ -17,8 +17,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -28,9 +26,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import app.example.BuildConfig
+import app.example.R
 import com.slack.circuitx.overlays.BottomSheetOverlay
 
 /**
@@ -73,7 +73,7 @@ private fun AppInfoContent(
                 horizontalArrangement = Arrangement.Center,
             ) {
                 Icon(
-                    imageVector = Icons.Default.Info,
+                    painter = painterResource(id = R.drawable.baseline_info_24),
                     contentDescription = "App Info",
                     tint = MaterialTheme.colorScheme.primary,
                 )

--- a/app/src/main/res/drawable/baseline_info_24.xml
+++ b/app/src/main/res/drawable/baseline_info_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-6h2v6zM13,9h-2L11,7h2v2z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/baseline_person_24.xml
+++ b/app/src/main/res/drawable/baseline_person_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+    
+</vector>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,15 +3,18 @@ activityCompose = "1.11.0"
 # https://developer.android.com/build/releases/gradle-plugin
 agp = "8.13.0"
 circuit = "0.30.0"
-composeBom = "2025.09.00"
+composeBom = "2025.09.01"
 coreKtx = "1.17.0"
 espressoCore = "3.7.0"
 googleFonts = "1.9.2"
 junit = "4.13.2"
 junitVersion = "1.3.0"
+
+# https://kotlinlang.org/docs/releases.html
 kotlin = "2.2.20"
 # The KSP (Kotlin Symbol Processing) plugin version must align with the Kotlin compiler version (2.2.20 in this case)
 ksp = "2.2.20-2.0.3"
+
 # Kotlin linter with built-in formatter
 # https://github.com/jeremymailen/kotlinter-gradle
 # https://github.com/pinterest/ktlint

--- a/setup-project.sh
+++ b/setup-project.sh
@@ -178,6 +178,11 @@ if [ "$REMOVE_EXAMPLES" = true ]; then
     find ./ -name "Example*.kt" -type f -delete
     find ./ -name "*Example*.kt" -type f -delete
     echo "Example files removed"
+    # Remove baseline_* vector drawable icons
+    echo "🗑️  Removing baseline_* vector drawable icons..."
+    rm -f ./app/src/main/res/drawable/baseline_info_24.xml
+    rm -f ./app/src/main/res/drawable/baseline_person_24.xml
+    echo "baseline_* vector drawable icons removed"
 else
     echo "📚 Step 6: Keeping Example* files for reference..."
 fi


### PR DESCRIPTION
Icons were removed in latest release - See https://bsky.app/profile/riggaroo.dev/post/3lzpyhpcx7k2x

----
This pull request updates the handling of vector drawable icons in the app, replacing usage of Material Icons with local baseline vector drawables and ensuring their correct management in project setup and CI. It also bumps the Compose BOM version and makes minor dependency updates.

**Icon handling and resource management:**

* Replaces all usages of `Icons.Default.Person` and `Icons.Default.Info` with local vector drawables (`baseline_person_24.xml` and `baseline_info_24.xml`) via `painterResource` in `ExampleEmailDetailsScreen.kt`, `ExampleInboxScreen.kt`, and `AppInfoOverlay.kt`. [[1]](diffhunk://#diff-4e466fc8cbff747ee03cb2e5a8d1b5681ec9404c91bd7ea5510fc9a0ecf681f9L115-R115) [[2]](diffhunk://#diff-4e466fc8cbff747ee03cb2e5a8d1b5681ec9404c91bd7ea5510fc9a0ecf681f9L180-R180) [[3]](diffhunk://#diff-3533e97f463997492a432253a921afee479466b102e20c2cbb969dfba18880d1L124-R124) [[4]](diffhunk://#diff-ed5e1589265b5a57acc06b170c0defe37562f918122acd7861bc6549b7e890f4L76-R76)
* Removes unused imports of Material Icons from affected Kotlin files. [[1]](diffhunk://#diff-4e466fc8cbff747ee03cb2e5a8d1b5681ec9404c91bd7ea5510fc9a0ecf681f9L23-L24) [[2]](diffhunk://#diff-3533e97f463997492a432253a921afee479466b102e20c2cbb969dfba18880d1L16-L17) [[3]](diffhunk://#diff-ed5e1589265b5a57acc06b170c0defe37562f918122acd7861bc6549b7e890f4L20-L21)
* Adds the new vector drawable resources `baseline_info_24.xml` and `baseline_person_24.xml` to the project. [[1]](diffhunk://#diff-9fd07c953514e63801758efc7af77e04aed003934629b83c3231e647def9eb41R1-R5) [[2]](diffhunk://#diff-8ebbb0e3e24e30aa46f339c190f44dbaa9d35d305f60e5400a1d3c45c497f04cR1-R5)

**Project setup and validation:**

* Updates `setup-project.sh` to remove `baseline_*` vector drawable icons when example files are removed, and adds a CI step in `.github/workflows/test-setup-script.yml` to validate that these icons are deleted when expected. [[1]](diffhunk://#diff-ae03887783740c86853a2a51863e7ac9e8c116bdc9a968edd41dc0b671cf5966R181-R185) [[2]](diffhunk://#diff-cb4bb254ffaa43097ef10bfc9c49369ed4114816e0aca2b8d37b6add46a12241R142-R152)

**Dependency updates:**

* Bumps the Compose BOM version from `2025.09.00` to `2025.09.01` in `gradle/libs.versions.toml` and adds minor formatting.