### PR TITLE
fix: preserve existing git repository in setup script

### DIFF
--- a/setup-project.sh
+++ b/setup-project.sh
@@ -368,44 +368,45 @@ if [ -f "renovate.json" ]; then
     echo "📋 Found renovate.json - you may want to review and configure this for your project"
 fi
 
-# Remove git history for fresh start
-echo "🔄 Removing git history for fresh start..."
-rm -rf .git/ 2>/dev/null || true
-
-# Step 10: Create initial git repository
-echo "📦 Step 10: Initializing new git repository..."
+# Step 10: Handle git repository initialization
+echo "📦 Step 10: Checking git repository status..."
 
 # Check if git is installed
 if ! command -v git &> /dev/null; then
-    echo "❌ Error: git is not installed or not available in PATH."
-    exit 1
-fi
+    echo "⚠️  Warning: git is not installed or not available in PATH."
+    echo "   You can initialize git manually later with: git init"
+else
+    # Check if git is already initialized
+    if [ -d ".git" ]; then
+        echo "ℹ️  Git repository already exists - preserving existing repository"
+        echo "   You can review changes with: git status"
+        echo "   Remember to commit your customization changes when ready"
+    else
+        echo "🔄 Creating new git repository for fresh start..."
+        
+        # Initialize git repository and handle errors
+        if ! git init; then
+            echo "❌ Error: Failed to initialize git repository."
+            exit 1
+        fi
 
-# Ensure .git directory does not already exist
-if [ -d ".git" ]; then
-    echo "❌ Error: .git directory already exists. Cannot initialize a new repository."
-    exit 1
-fi
+        if ! git add .; then
+            echo "❌ Error: Failed to stage files for commit."
+            exit 1
+        fi
 
-# Initialize git repository and handle errors
-if ! git init; then
-    echo "❌ Error: Failed to initialize git repository."
-    exit 1
-fi
-
-if ! git add .; then
-    echo "❌ Error: Failed to stage files for commit."
-    exit 1
-fi
-
-if ! git commit -m "Initial commit: $APPNAME
+        if ! git commit -m "Initial commit: $APPNAME
 
 - Customized from android-compose-app-template
 - Package: $PACKAGE  
 - Circuit + Metro architecture
 - WorkManager kept: $([ "$REMOVE_WORKMANAGER" = false ] && echo "true" || echo "false")"; then
-    echo "❌ Error: Failed to create initial commit."
-    exit 1
+            echo "❌ Error: Failed to create initial commit."
+            exit 1
+        fi
+        
+        echo "✅ New git repository initialized with initial commit"
+    fi
 fi
 
 echo ""
@@ -433,13 +434,12 @@ if [ "$KEEP_SCRIPT" = false ]; then
     echo "🚀 Happy coding!"
 else
     echo "📜 Setup script kept for debugging/re-running if needed"
+    # Always clean up Android environment setup script (it's not needed after project setup)
+    if [ -f "setup-android-env.sh" ]; then
+        echo "ℹ️ Removing Android environment setup script (no longer needed)..."
+        rm -f setup-android-env.sh
+    fi
     echo "🚀 Happy coding!"
     echo ""
-    echo "💡 Tip: You can safely delete the setup-project.sh and setup-android-env.sh when you no longer need them"
-fi
-
-# Always clean up Android environment setup script (it's not needed after project setup)
-if [ -f "setup-android-env.sh" ] && [ "$KEEP_SCRIPT" = true ]; then
-    echo "ℹ️ Removing Android environment setup script (no longer needed)..."
-    rm -f setup-android-env.sh
+    echo "💡 Tip: You can safely delete the setup-project.sh when you no longer need it"
 fi


### PR DESCRIPTION
## 🐛 Problem

The `setup-project.sh` script was forcefully removing the `.git` directory (`rm -rf .git/`), which could cause **data loss** for users who already have the template cloned and initialized with git. This was particularly problematic for users who wanted to customize the template while preserving their existing commit history.

## ✨ Solution

Updated the git repository initialization logic in `setup-project.sh` to be safer and more intelligent:

### Key Changes

1. **Preserve Existing Repositories** 
   - Check if `.git` directory exists before attempting any initialization
   - If it exists, preserve it and inform the user to commit changes manually
   - Provide clear guidance messages for both scenarios

2. **Smarter Initialization**
   - Only create a new git repository if one doesn't already exist
   - Make git optional with helpful warnings if not installed
   - Better error handling throughout the git workflow

3. **Improved Code Organization**
   - Reorganized cleanup logic for `setup-android-env.sh` 
   - Clearer user messages and guidance
   - More maintainable code structure

## 📋 Testing

- ✅ Tested with existing git repository (preserves history)
- ✅ Tested without git repository (creates new one)
- ✅ Tested without git installed (graceful degradation with warnings)
- ✅ Script executes successfully in all scenarios

## 📊 Impact

- **1 file changed**: `setup-project.sh`
- **35 insertions(+), 35 deletions(-)**
- Net-neutral line count, focused on improving logic flow

## 🎯 Benefits

- ✅ Prevents accidental data loss
- ✅ More user-friendly for template users
- ✅ Safer for iterative customization workflows
- ✅ Better error handling and user guidance
- ✅ Makes the template more robust for various use cases