### PR TITLE
fix: Update app name in settings.gradle.kts during project setup

### DIFF
--- a/setup-project.sh
+++ b/setup-project.sh
@@ -168,9 +168,10 @@ if [ -f "app/src/main/java/$SUBDIR/CircuitApp.kt" ]; then
     echo "Renamed CircuitApp.kt to ${APPNAME}App.kt"
 fi
 
-# Step 5: Update app name in strings.xml and other XML files
-echo "🏷️  Step 5: Updating app name in XML files..."
+# Step 5: Update app name in strings.xml and settings.gradle.kts
+echo "🏷️  Step 5: Updating app name in resource and configuration files..."
 find ./ -name "strings.xml" -exec sed -i.bak "s/<string name=\"app_name\">.*<\/string>/<string name=\"app_name\">$APPNAME<\/string>/g" {} \;
+find ./ -name "settings.gradle.kts" -exec sed -i.bak "s/rootProject\.name = \".*\"/rootProject.name = \"$APPNAME\"/g" {} \;
 
 # Step 6: Handle Example files
 if [ "$REMOVE_EXAMPLES" = true ]; then


### PR DESCRIPTION
## Description

Fixes two issues in the `setup-project.sh` script where the app name wasn't being updated in all necessary files.

## Issues Fixed

1. **settings.gradle.kts**: `rootProject.name` remained as "Circuit App Template" after running the setup script
2. **strings.xml**: Verified existing fix works correctly for updating app_name

## Changes Made

- Added sed command in Step 5 to update `rootProject.name` in `settings.gradle.kts`
- Updated Step 5 echo message for clarity: "Updating app name in resource and configuration files"

## Testing

✅ Simulated fixes with temporary files matching actual project structure  
✅ Tested with multiple app names: TodoApp, MyNotesApp, PhotoGallery, TaskMaster, WeatherPro  
✅ Verified both files are correctly updated in all test cases  
✅ Confirmed sed patterns work on macOS (bash 3.2+)  
✅ Full project structure simulation successful  

## Example

When running: `bash setup-project.sh com.myapp.todo TodoApp`

**Before this fix:**
- ❌ `settings.gradle.kts`: `rootProject.name = "Circuit App Template"`

**After this fix:**
- ✅ `settings.gradle.kts`: `rootProject.name = "TodoApp"`
- ✅ `strings.xml`: `<string name="app_name">TodoApp</string>`

## Files Changed

- `setup-project.sh` - Added 1 line to update settings.gradle.kts, updated echo message