### PR TITLE
Fix release workflow to work without secrets configured

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -52,6 +52,7 @@ jobs:
           fi
 
       - name: Decode keystore from base64
+        if: ${{ secrets.KEYSTORE_BASE64 != '' }}
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > keystore/app-release.keystore
 
@@ -60,7 +61,8 @@ jobs:
       - name: Build Release APK and AAB
         run: ./gradlew assembleRelease bundleRelease --parallel --daemon
         env:
-          KEYSTORE_FILE: keystore/app-release.keystore
+          # Only set KEYSTORE_FILE if the secret is configured, otherwise fall back to debug keystore
+          KEYSTORE_FILE: ${{ secrets.KEYSTORE_BASE64 != '' && 'keystore/app-release.keystore' || '' }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,8 @@
 
 This guide walks you through setting up automated release builds and signing for your Android app template.
 
+> **Note:** The release workflow will work without secrets configured by using the debug keystore as a fallback. However, for production releases, you **must** configure the secrets to use a proper production keystore.
+
 ## Prerequisites
 
 - [ ] You have admin access to the GitHub repository


### PR DESCRIPTION
## Problem

The `android-release.yml` workflow was failing with the error:
```
Tag number over 30 is not supported
```

This happened because the workflow attempted to decode an empty/unset `KEYSTORE_BASE64` secret, creating an invalid keystore file. When `KEYSTORE_FILE` environment variable was set to point to this invalid file, the build failed.

## Root Cause

When secrets are not configured (which is expected for the template repository), the workflow was:
1. Decoding empty secret → creating invalid `keystore/app-release.keystore`
2. Setting `KEYSTORE_FILE=keystore/app-release.keystore` → pointing to invalid file
3. Build tries to use invalid keystore → fails with cryptic error

## Solution

Updated the workflow to gracefully handle missing secrets:

1. **Conditional keystore decode**: Only decode keystore when `KEYSTORE_BASE64` secret is set
2. **Conditional environment variable**: Only set `KEYSTORE_FILE` when secret is configured
3. **Fallback behavior**: When secrets are not set, `build.gradle.kts` automatically falls back to `debug.keystore`

This allows:
- ✅ Template repository to build successfully without secrets
- ✅ Users to test the workflow before setting up production keystore
- ✅ Production builds with proper keystore when secrets are configured

## Changes

- Modified `android-release.yml` to conditionally decode keystore
- Updated `RELEASE.md` to clarify fallback behavior

## Testing

The workflow will now:
- Work immediately on template without configuration
- Use debug keystore for signing when secrets are not set
- Use production keystore when secrets are properly configured (per RELEASE.md guide)

## Related

- Complements PR #252 (keystore compatibility fix)
- Resolves signing errors introduced in PR #250