### PR TITLE
Fix workflow secrets syntax error

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -51,20 +51,26 @@ jobs:
             echo "📦 Building snapshot from main branch"
           fi
 
-      - name: Decode keystore from base64
-        if: ${{ secrets.KEYSTORE_BASE64 != '' }}
+      - name: Setup keystore
         run: |
-          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > keystore/app-release.keystore
+          # Only decode and use production keystore if secrets are configured
+          if [ -n "${{ secrets.KEYSTORE_BASE64 }}" ]; then
+            echo "Using production keystore from secrets"
+            echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > keystore/app-release.keystore
+            echo "KEYSTORE_FILE=keystore/app-release.keystore" >> $GITHUB_ENV
+            echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
+            echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
+          else
+            echo "⚠️ Production keystore not configured, falling back to debug keystore"
+            echo "KEYSTORE_FILE=" >> $GITHUB_ENV
+            echo "KEYSTORE_PASSWORD=android" >> $GITHUB_ENV
+            echo "KEY_ALIAS=androiddebugkey" >> $GITHUB_ENV
+          fi
 
       - name: Ensure gradlew is executable
         run: chmod +x gradlew
       - name: Build Release APK and AAB
         run: ./gradlew assembleRelease bundleRelease --parallel --daemon
-        env:
-          # Only set KEYSTORE_FILE if the secret is configured, otherwise fall back to debug keystore
-          KEYSTORE_FILE: ${{ secrets.KEYSTORE_BASE64 != '' && 'keystore/app-release.keystore' || '' }}
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
 
       - name: Extract version name
         id: version


### PR DESCRIPTION
## Problem

The previous fix in PR #255 caused a workflow validation error:
```
Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.KEYSTORE_BASE64 != ''
```

The `secrets` context cannot be used directly in `if` conditions at the step level in GitHub Actions.

## Solution

Changed the approach to use a shell script within a `run` step that:
1. Checks if `secrets.KEYSTORE_BASE64` is set using bash `-n` test
2. If set: decodes the production keystore and sets environment variables
3. If not set: uses debug keystore credentials and sets environment variables accordingly

The environment variables are persisted using `$GITHUB_ENV` so subsequent steps can use them.

## Changes

- Replaced conditional `if` step with unified "Setup keystore" step
- Removed separate env vars from build step (now set in GITHUB_ENV)
- Added informative messages for which keystore is being used

## Testing

This approach:
- ✅ Works with GitHub Actions syntax validation
- ✅ Properly handles missing secrets (falls back to debug keystore)
- ✅ Uses production keystore when secrets are configured
- ✅ Provides clear logging of which keystore is used

## Related

- Supersedes PR #255 (fixes the syntax error)
- Complements PR #252 (keystore compatibility)
- Resolves issues from PR #250