### PR TITLE
Fix empty KEYSTORE_FILE env var causing Gradle error

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -55,16 +55,15 @@ jobs:
         run: |
           # Only decode and use production keystore if secrets are configured
           if [ -n "${{ secrets.KEYSTORE_BASE64 }}" ]; then
-            echo "Using production keystore from secrets"
+            echo "✅ Using production keystore from secrets"
             echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > keystore/app-release.keystore
             echo "KEYSTORE_FILE=keystore/app-release.keystore" >> $GITHUB_ENV
             echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
             echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
           else
             echo "⚠️ Production keystore not configured, falling back to debug keystore"
-            echo "KEYSTORE_FILE=" >> $GITHUB_ENV
-            echo "KEYSTORE_PASSWORD=android" >> $GITHUB_ENV
-            echo "KEY_ALIAS=androiddebugkey" >> $GITHUB_ENV
+            # Don't set KEYSTORE_FILE - let build.gradle.kts fall back to debug keystore
+            # The build.gradle.kts checks System.getenv("KEYSTORE_FILE") and uses debug keystore when null
           fi
 
       - name: Ensure gradlew is executable


### PR DESCRIPTION
## Problem

The workflow is failing with:
```
Cannot convert '' to File.
Build file '/home/runner/.../app/build.gradle.kts' line: 45
```

## Root Cause

In PR #256, when secrets aren't configured, we set:
```bash
echo "KEYSTORE_FILE=" >> $GITHUB_ENV
```

This sets `KEYSTORE_FILE` to an empty string, but `build.gradle.kts` line 45 tries to convert it:
```kotlin
val keystoreFile = System.getenv("KEYSTORE_FILE")?.let { rootProject.file(it) }
    ?: file("../keystore/debug.keystore")
```

When `KEYSTORE_FILE=""` (empty string, not null), the `?.let` block executes and tries to convert empty string to File, causing the error.

## Solution

Don't set the `KEYSTORE_FILE` environment variable at all when using debug keystore fallback. When the env var is **unset** (null), `System.getenv("KEYSTORE_FILE")` returns `null`, triggering the `?: fallback` to debug keystore.

## Changes

- Removed setting `KEYSTORE_FILE`, `KEYSTORE_PASSWORD`, and `KEY_ALIAS` env vars when secrets aren't configured
- Added comment explaining the fallback behavior
- Improved logging message with ✅ emoji for clarity

## Testing

With this fix:
- ✅ When secrets are not set: env vars are unset → `build.gradle.kts` uses debug keystore
- ✅ When secrets are set: env vars are set → `build.gradle.kts` uses production keystore

## Related

- Fixes regression from PR #256
- Part of the ongoing keystore configuration improvements from PR #250, #252, #255, #256