### PR TITLE
docs: update READMEs to document automated release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ An Android App template that is preconfigured with ⚡️ Circuit UDF architectu
 ## What do you get in this template? 📜
 * ✔️ [Circuit](https://github.com/slackhq/circuit) library setup for the app
 * ✔️ [Metro](https://zacsweers.github.io/metro/) Dependency Injection for all Circuit Screens & Presenter combo
-* ✔️ GitHub Actions for CI
+* ✔️ GitHub Actions for CI and automated release builds
+* ✔️ Automated APK/AAB builds with keystore signing (see [RELEASE.md](RELEASE.md))
 * ✔️ [Google font](https://github.com/hossain-khan/android-compose-app-template/blob/main/app/src/main/java/app/example/ui/theme/Type.kt#L9-L14) for choosing different app font.
 * ✔️ `BuildConfig` turned on with example of reading config from `local.properties` file.
 * ✔️ [Kotlin formatter](https://github.com/jeremymailen/kotlinter-gradle) plugin for code formatting and linting
@@ -95,6 +96,7 @@ These still need to be done manually after using the script:
 * [ ] Configure [renovate](https://github.com/apps/renovate) for dependency management or remove [`renovate.json`](https://github.com/hossain-khan/android-compose-app-template/blob/main/renovate.json) file
 * [ ] Choose [Google font](https://github.com/hossain-khan/android-compose-app-template/blob/main/app/src/main/java/app/example/ui/theme/Type.kt#L16-L30) for your app, or remove it.
 * [ ] Verify Android Gradle Plugin (AGP) version compatibility with your development environment in `gradle/libs.versions.toml`
+* [ ] **(Optional)** Set up production keystore for release builds - see [RELEASE.md](RELEASE.md) for automated APK signing
 
 </details>
 

--- a/keystore/README.md
+++ b/keystore/README.md
@@ -4,16 +4,23 @@ This directory contains keystores for signing Android builds.
 
 ### Debug Keystore
 
-For local development, a debug keystore (`debug.keystore`) is used with standard Android debug credentials:
+For local development and CI builds without production keystore configured, a debug keystore (`debug.keystore`) is used with standard Android debug credentials:
 - Store Password: `android`
 - Key Alias: `androiddebugkey`
 - Key Password: `android`
 
+**Note:** The release workflow automatically falls back to this debug keystore when production secrets are not configured, allowing the template to build successfully out of the box.
+
 See https://developer.android.com/studio/publish/app-signing#debug-mode
 
 ### Release Keystore (Production)
-Release builds are signed by workflows using securely stored keystore files and credentials.
-As soon as a tagged release is created, the release workflow signs the APK using the production keystore and uploads it to GitHub Releases.
+
+**For production releases**, you should configure a production keystore following the setup guide in [RELEASE.md](../RELEASE.md).
+
+Once configured:
+- Release builds are automatically signed with your production keystore
+- APK and AAB files are built on every push to main branch
+- When a GitHub release is created, signed APK/AAB are automatically attached
 
 For example:
 


### PR DESCRIPTION
## Summary

Updates README documentation to reflect the new automated release workflow capabilities added in recent PRs.

## Changes

### Main README.md
- ✅ Updated features list to include "GitHub Actions for CI and automated release builds"
- ✅ Added "Automated APK/AAB builds with keystore signing" as a key feature
- ✅ Added optional step for production keystore setup in post-process checklist
- ✅ Links to RELEASE.md for detailed configuration instructions

### keystore/README.md
- ✅ Clarified that debug keystore is used as automatic fallback when production secrets aren't configured
- ✅ Explained that production keystore setup is optional but recommended for production releases
- ✅ Listed benefits of configuring production keystore:
  - Automatic signing with production credentials
  - APK/AAB builds on every push to main
  - Automatic attachment to GitHub releases

## Context

After merging PRs #250, #252, #256, and #257, the template now includes:
- Automated release build workflow (`android-release.yml`)
- Debug keystore fallback for builds without secrets configured
- Production keystore support via GitHub secrets

The documentation now accurately reflects these capabilities and guides users on optional production setup.

## Impact

- ✅ Users understand the template includes automated release capabilities
- ✅ Clear that the template works out of the box (with debug keystore)
- ✅ Optional production keystore setup is documented and linked