### PR TITLE
Fix setup script to preserve workflows and required keystore

### DIFF
--- a/setup-project.sh
+++ b/setup-project.sh
@@ -383,7 +383,9 @@ rm -f .github/workflows/test-setup-script.yml 2>/dev/null || true
 rm -f CONTRIBUTING.md 2>/dev/null || true
 rm -f LICENSE 2>/dev/null || true
 rm -f RELEASE.md 2>/dev/null || true
-rm -rf keystore/ 2>/dev/null || true
+# Keep keystore/ directory - it contains debug.keystore needed for release builds
+# Remove only the README inside keystore/ as it's template-specific
+rm -f keystore/README.md 2>/dev/null || true
 
 # Remove renovate config (user can add back if needed)
 if [ -f "renovate.json" ]; then


### PR DESCRIPTION
## Problem

The `setup-project.sh` script was removing the entire `.github/` directory and `keystore/` directory, which now contain valuable CI workflows and the required debug keystore for automated release builds.

## Solution

Updated the script to selectively remove only template-specific files while preserving production-ready workflows and required build assets.

## Changes

### Preserved:
- ✅ `.github/workflows/android.yml` - CI builds on PR and main
- ✅ `.github/workflows/android-lint.yml` - Code quality checks
- ✅ `.github/workflows/android-release.yml` - Automated APK/AAB builds
- ✅ `.github/workflows/test-keystore-apk-signing.yml` - Keystore validation
- ✅ `keystore/debug.keystore` - **Required** for release builds to work

### Removed (template-specific):
- ❌ `.github/workflows/test-setup-script.yml` - Tests the setup script itself
- ❌ `RELEASE.md` - Production keystore setup guide (users can reference template if needed)
- ❌ `keystore/README.md` - Template-specific documentation

### Updated generated README:
Added section explaining:
- GitHub Actions workflows are included
- Debug keystore is used by default
- How to set up production keystore later (with GitHub secrets)

## Why keep debug.keystore?

The `app/build.gradle.kts` signing configuration references `keystore/debug.keystore` as the fallback when production keystore environment variables are not set:

```kotlin
val keystoreFile = System.getenv("KEYSTORE_FILE")?.let { rootProject.file(it) }
    ?: file("../keystore/debug.keystore")  // Falls back to debug keystore
```

Without this file, the release workflow would fail on new projects.

## Benefits

New projects created from the template will have:
- ✅ Working CI out of the box
- ✅ Automated release builds that actually work (with debug keystore)
- ✅ Easy upgrade path to production keystore (set GitHub secrets)
- ✅ Clean setup without template-specific documentation

## Testing

The workflows will continue to work with debug keystore fallback, and users can upgrade to production keystore by following the RELEASE.md guide in the template repository.