### PR TITLE
Add missing INTERNET permission to AndroidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".CircuitApp"
         android:appComponentFactory=".di.ComposeAppComponentFactory"


### PR DESCRIPTION
The app was crashing with SecurityException due to missing INTERNET permission in the manifest. Added <uses-permission> declaration to fix network requests.