### PR TITLE
docs: Add networking stack to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An Android App template that is preconfigured with ⚡️ Circuit UDF architectu
 ## What do you get in this template? 📜
 * ✔️ [Circuit](https://github.com/slackhq/circuit) library setup for the app
 * ✔️ [Metro](https://zacsweers.github.io/metro/) Dependency Injection for all Circuit Screens & Presenter combo
+* ✔️ [OkHttp](https://square.github.io/okhttp/) & [Retrofit](https://square.github.io/retrofit/) networking with [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) and sample API implementation
 * ✔️ GitHub Actions for CI and automated release builds
 * ✔️ Automated APK/AAB builds with keystore signing (see [RELEASE.md](RELEASE.md))
 * ✔️ [Google font](https://github.com/hossain-khan/android-compose-app-template/blob/main/app/src/main/java/app/example/ui/theme/Type.kt#L9-L14) for choosing different app font.


### PR DESCRIPTION
Update the 'What do you get in this template?' section to mention the modern networking stack with OkHttp, Retrofit, and kotlinx-serialization.

This reflects the networking layer implementation added in PR #350, which includes:
- OkHttp with logging interceptor
- Retrofit with kotlinx-serialization converter
- Sample API implementation (EmailApiService)
- Proper DI setup with NetworkingGraph

## Related
- PR #350: Implement networking layer with OkHttp, Retrofit & kotlinx-serialization