### PR TITLE
[codex] Upgrade Circuit to 0.34.0

### DIFF
--- a/app/src/main/java/app/example/MainActivity.kt
+++ b/app/src/main/java/app/example/MainActivity.kt
@@ -71,8 +71,8 @@ class MainActivity
                                     navigator = navigator,
                                     navStack = navStack,
                                     decoratorFactory =
-                                        remember(navigator) {
-                                            GestureNavigationDecorationFactory(onBackInvoked = navigator::pop)
+                                        remember {
+                                            GestureNavigationDecorationFactory()
                                         },
                                 )
                             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ activityCompose = "1.13.0"
 # https://developer.android.com/build/releases/gradle-plugin
 # AGP 9.1 requires Gradle 9.3.1 or higher
 agp = "9.2.1"
-circuit = "0.33.1"
+circuit = "0.34.0"
 composeBom = "2026.05.01"
 coreKtx = "1.19.0"
 # https://github.com/Kotlin/kotlinx.coroutines/releases
@@ -115,5 +115,4 @@ kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }
 
 # https://kotlinlang.org/docs/serialization.html
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-
 


### PR DESCRIPTION
## What changed
- upgraded Circuit from `0.33.1` to `0.34.0`
- updated `MainActivity` to use `GestureNavigationDecorationFactory()` without the removed `onBackInvoked` parameter

## Why
Circuit `0.34.0` is the latest available release and includes a breaking navigation decorator API change. This project used the older gesture navigation decorator signature, so the migration updates the dependency and adapts the call site to the new API.

## Impact
- keeps the project on the latest Circuit release
- preserves predictive back gesture integration with the new decorator contract
- no additional source changes were required after recompiling against `0.34.0`

## Validation
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:testDebugUnitTest`