### PR TITLE
[codex] Suppress Theme dynamic color lint warning

### DIFF
--- a/app/src/main/java/app/example/ui/theme/Theme.kt
+++ b/app/src/main/java/app/example/ui/theme/Theme.kt
@@ -1,5 +1,8 @@
 package app.example.ui.theme
+import android.annotation.SuppressLint
 import android.os.Build
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
@@ -32,7 +35,8 @@ fun CircuitAppTheme(
 ) {
     val colorScheme =
         when {
-            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            @SuppressLint("NewApi") // The `VERSION_CODES.S` check already in place
+            dynamicColor && VERSION.SDK_INT >= VERSION_CODES.S -> {
                 val context = LocalContext.current
                 if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
             }


### PR DESCRIPTION
## What changed
- added a targeted lint suppression for the dynamic Material 3 color scheme calls in `CircuitAppTheme`
- kept the existing runtime API guard for Android 12+ dynamic color

## Why
Android Lint reports `dynamicDarkColorScheme()` and `dynamicLightColorScheme()` as `NewApi` calls even with the existing SDK version guard in place. This change suppresses that false positive without restructuring the theme logic.

## Impact
- removes the blocking lint error in `Theme.kt`
- preserves the current behavior for dynamic color selection
- keeps the fix scoped to the existing call site

## Validation
- user confirmed the build passes locally