### PR TITLE
Fix draft promotion and auto-refresh returning to Inbox

### DIFF
--- a/app/src/main/java/app/example/circuit/ExampleComposeEmailScreen.kt
+++ b/app/src/main/java/app/example/circuit/ExampleComposeEmailScreen.kt
@@ -152,7 +152,7 @@ class ComposeEmailPresenter
                 try {
                     when (action) {
                         PendingAction.SAVE_DRAFT -> emailRepository.saveDraft(to, subject, body)
-                        PendingAction.SEND -> emailRepository.sendEmail(to, subject, body)
+                        PendingAction.SEND -> emailRepository.sendEmail(to, subject, body, screen.draftId)
                     }
                     navigator.pop()
                 } catch (e: HttpException) {

--- a/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
+++ b/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
@@ -146,6 +146,14 @@ class InboxPresenter
             var retryTrigger by rememberRetained { mutableStateOf(0) }
             var pendingDeleteId by rememberRetained { mutableStateOf<String?>(null) }
 
+            var lastSelectedTab by rememberRetained { mutableStateOf(ScreenTab.INBOX) }
+            var lastRetryTrigger by rememberRetained { mutableStateOf(0) }
+            if (selectedTab != lastSelectedTab || retryTrigger != lastRetryTrigger) {
+                emails = null
+                lastSelectedTab = selectedTab
+                lastRetryTrigger = retryTrigger
+            }
+
             LaunchedEffect(selectedTab, retryTrigger) {
                 emails = null
                 errorMessage = null

--- a/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
+++ b/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
@@ -72,6 +72,7 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 
@@ -157,6 +158,12 @@ class InboxPresenter
                         }
                 } catch (e: Exception) {
                     errorMessage = e.message ?: "Unknown error"
+                }
+            }
+
+            LaunchedEffect(emailRepository) {
+                emailRepository.updates.collect {
+                    retryTrigger++
                 }
             }
 

--- a/app/src/main/java/app/example/data/network/dto/SendEmailRequest.kt
+++ b/app/src/main/java/app/example/data/network/dto/SendEmailRequest.kt
@@ -14,4 +14,5 @@ data class SendEmailRequest(
     val sender: String,
     val senderEmail: String,
     val recipients: List<String>,
+    val draftId: String? = null,
 )

--- a/app/src/main/java/app/example/data/repository/EmailRepository.kt
+++ b/app/src/main/java/app/example/data/repository/EmailRepository.kt
@@ -1,6 +1,7 @@
 package app.example.data.repository
 
 import app.example.data.model.Email
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Repository interface for email operations.
@@ -10,6 +11,9 @@ import app.example.data.model.Email
  * mapping API responses to domain [Email] models.
  */
 interface EmailRepository {
+    /** Flow emitting updates whenever the cache or repository data is mutated. */
+    val updates: Flow<Unit>
+
     /**
      * Returns all emails in the inbox.
      *
@@ -55,6 +59,7 @@ interface EmailRepository {
         to: String,
         subject: String,
         body: String,
+        draftId: String? = null,
     ): Email
 
     /**

--- a/app/src/main/java/app/example/data/repository/EmailRepositoryImpl.kt
+++ b/app/src/main/java/app/example/data/repository/EmailRepositoryImpl.kt
@@ -8,6 +8,9 @@ import app.example.data.network.dto.toDomain
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 
 /**
  * Production implementation of [EmailRepository] that fetches emails from the
@@ -25,6 +28,9 @@ class EmailRepositoryImpl
     constructor(
         private val apiService: EmailApiService,
     ) : EmailRepository {
+        private val _updates = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+        override val updates: Flow<Unit> = _updates.asSharedFlow()
+
         /** In-memory cache populated on the first successful inbox fetch. */
         private var cachedEmails: List<Email>? = null
 
@@ -75,6 +81,7 @@ class EmailRepositoryImpl
             to: String,
             subject: String,
             body: String,
+            draftId: String?,
         ): Email {
             val recipients = to.split(",").map { it.trim() }.filter { it.isNotEmpty() }
             val request =
@@ -84,11 +91,14 @@ class EmailRepositoryImpl
                     sender = "Me",
                     senderEmail = "me@example.com",
                     recipients = recipients,
+                    draftId = draftId,
                 )
             val result = apiService.sendEmail(request).data.toDomain()
-            // Invalidate inbox and sent caches so sent email appears on next loads
+            // Invalidate inbox, sent, and drafts caches so sent/draft emails update on next loads
             cachedEmails = null
             cachedSentEmails = null
+            cachedDraftEmails = null
+            _updates.tryEmit(Unit)
             return result
         }
 
@@ -113,6 +123,7 @@ class EmailRepositoryImpl
             val result = apiService.createDraft(request).data.toDomain()
             // Invalidate draft cache so it is refreshed on next load
             cachedDraftEmails = null
+            _updates.tryEmit(Unit)
             return result
         }
 
@@ -124,6 +135,7 @@ class EmailRepositoryImpl
             val response = apiService.deleteEmail(draftId)
             if (response.success) {
                 cachedDraftEmails = cachedDraftEmails?.filter { it.id != draftId }
+                _updates.tryEmit(Unit)
             }
             return response.success
         }

--- a/app/src/test/java/app/example/circuit/FakeEmailRepository.kt
+++ b/app/src/test/java/app/example/circuit/FakeEmailRepository.kt
@@ -2,6 +2,8 @@ package app.example.circuit
 
 import app.example.data.model.Email
 import app.example.data.repository.EmailRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 
 /**
  * A test-only fake implementation of [EmailRepository].
@@ -19,6 +21,8 @@ class FakeEmailRepository(
     private val getDraftsException: Exception? = null,
     private val getSentException: Exception? = null,
 ) : EmailRepository {
+    override val updates: Flow<Unit> = emptyFlow()
+
     override suspend fun getInboxEmails(): List<Email> {
         getInboxException?.let { throw it }
         return inboxEmails
@@ -43,6 +47,7 @@ class FakeEmailRepository(
         to: String,
         subject: String,
         body: String,
+        draftId: String?,
     ): Email = testEmail(id = "sent-1", subject = subject, body = body, status = "sent")
 
     override suspend fun saveDraft(

--- a/app/src/test/java/app/example/circuit/InboxPresenterTest.kt
+++ b/app/src/test/java/app/example/circuit/InboxPresenterTest.kt
@@ -107,11 +107,10 @@ class InboxPresenterTest {
                 // Select DRAFTS tab
                 successState.eventSink(InboxScreen.Event.TabSelected(ScreenTab.DRAFTS))
 
-                // Emits Success tab change with old inbox emails first
-                val firstEmit = awaitItem() as InboxScreen.State.Success
-                assertEquals(ScreenTab.DRAFTS, firstEmit.selectedTab)
+                // Emits Loading immediately as emails list is cleared synchronously
+                assertEquals(InboxScreen.State.Loading, awaitItem())
 
-                // Emits Success with drafts (loading is skipped synchronously in tests)
+                // Emits Success with drafts
                 val draftsState = awaitItem() as InboxScreen.State.Success
                 assertEquals(ScreenTab.DRAFTS, draftsState.selectedTab)
                 assertEquals("draft-1", draftsState.emails.first().id)


### PR DESCRIPTION
Passes the draftId to the POST /api/emails/send request payload to delete the original draft on the server. Implements a reactive updates flow in the EmailRepository to refresh tab lists in InboxPresenter whenever a repository mutation (send, save draft, delete draft) occurs.