### PR TITLE
Migrate to Circuit 0.36.0 features

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -122,8 +122,10 @@ dependencies {
     implementation(libs.androidx.ui.text.google.fonts)
     implementation(libs.androidx.ui.tooling.preview)
 
+    implementation(libs.circuit.codegen.annotations)
     implementation(libs.circuit.foundation)
     implementation(libs.circuit.overlay)
+    implementation(libs.circuit.serialization)
     implementation(libs.circuitx.android)
     implementation(libs.circuitx.effects)
     implementation(libs.circuitx.gestureNav)

--- a/app/src/main/java/app/example/MainActivity.kt
+++ b/app/src/main/java/app/example/MainActivity.kt
@@ -16,6 +16,8 @@ import com.slack.circuit.foundation.NavigableCircuitContent
 import com.slack.circuit.foundation.navstack.rememberSaveableNavStack
 import com.slack.circuit.foundation.rememberCircuitNavigator
 import com.slack.circuit.overlay.ContentWithOverlays
+import com.slack.circuit.retained.CircuitRetainedSettings
+import com.slack.circuit.retained.ExperimentalCircuitRetainedApi
 import com.slack.circuit.sharedelements.SharedElementTransitionLayout
 import com.slack.circuitx.gesturenavigation.GestureNavigationDecorationFactory
 import dev.zacsweers.metro.AppScope
@@ -50,8 +52,9 @@ class MainActivity
     constructor(
         private val circuit: Circuit,
     ) : ComponentActivity() {
-        @OptIn(ExperimentalSharedTransitionApi::class)
+        @OptIn(ExperimentalSharedTransitionApi::class, ExperimentalCircuitRetainedApi::class)
         override fun onCreate(savedInstanceState: Bundle?) {
+            CircuitRetainedSettings.useFirstParty = true
             enableEdgeToEdge()
             super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/app/example/circuit/ExampleComposeEmailScreen.kt
+++ b/app/src/main/java/app/example/circuit/ExampleComposeEmailScreen.kt
@@ -45,16 +45,20 @@ import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.ParcelableScreen
 import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuit.serialization.CircuitSerializable
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
 import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
 import org.json.JSONObject
 import retrofit2.HttpException
 
 /** Screen for composing a new email or editing an existing draft. */
 @Parcelize
+@Serializable
+@CircuitSerializable(AppScope::class)
 data class ComposeEmailScreen(
     val draftId: String? = null,
 ) : ParcelableScreen {

--- a/app/src/main/java/app/example/circuit/ExampleEmailDetailsScreen.kt
+++ b/app/src/main/java/app/example/circuit/ExampleEmailDetailsScreen.kt
@@ -61,14 +61,18 @@ import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.ParcelableScreen
 import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuit.serialization.CircuitSerializable
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
 import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
 
 // See https://slackhq.github.io/circuit/screen/
 @Parcelize
+@Serializable
+@CircuitSerializable(AppScope::class)
 data class DetailScreen(
     val emailId: String,
 ) : ParcelableScreen {

--- a/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
+++ b/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
@@ -68,6 +68,7 @@ import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.ParcelableScreen
 import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuit.serialization.CircuitSerializable
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
@@ -75,6 +76,7 @@ import dev.zacsweers.metro.AssistedInject
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
 
 /** Standalone enum defining tabs in the unified email navigation container. */
 enum class ScreenTab {
@@ -84,6 +86,8 @@ enum class ScreenTab {
 }
 
 @Parcelize
+@Serializable
+@CircuitSerializable(AppScope::class)
 data object InboxScreen : ParcelableScreen {
     @Stable
     sealed interface State : CircuitUiState {

--- a/app/src/main/java/app/example/di/CircuitProviders.kt
+++ b/app/src/main/java/app/example/di/CircuitProviders.kt
@@ -3,6 +3,8 @@ package app.example.di
 import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.ui.Ui
+import com.slack.circuit.serialization.CircuitSerializerRegistration
+import com.slack.circuit.serialization.SerializableCircuitSaver
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Multibinds
@@ -48,6 +50,14 @@ interface CircuitProviders {
     @Multibinds fun uiFactories(): Set<Ui.Factory>
 
     /**
+     * Metro multi-binding method that provides a set of CircuitSerializerRegistration instances.
+     *
+     * Circuit codegen generates registrations for types annotated with @CircuitSerializable.
+     */
+    @Multibinds(allowEmpty = true)
+    fun serializerRegistrations(): Set<CircuitSerializerRegistration>
+
+    /**
      * Provides a singleton instance of Circuit with presenter and UI factories configured.
      *
      * The @JvmSuppressWildcards annotation is needed to prevent Kotlin from using
@@ -61,10 +71,12 @@ interface CircuitProviders {
     fun provideCircuit(
         presenterFactories: @JvmSuppressWildcards Set<Presenter.Factory>,
         uiFactories: @JvmSuppressWildcards Set<Ui.Factory>,
+        serializerRegistrations: @JvmSuppressWildcards Set<CircuitSerializerRegistration>,
     ): Circuit =
         Circuit
             .Builder()
             .addPresenterFactories(presenterFactories)
             .addUiFactories(uiFactories)
+            .setCircuitSaver(SerializableCircuitSaver(serializerRegistrations))
             .build()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ activityCompose = "1.13.0"
 # https://developer.android.com/build/releases/gradle-plugin
 # AGP 9.1 requires Gradle 9.3.1 or higher
 agp = "9.3.1"
-circuit = "0.35.1"
+circuit = "0.36.0"
 composeBom = "2026.06.01"
 material3 = "1.5.0-alpha24"
 material3Adaptive = "1.3.0-rc01"
@@ -71,8 +71,10 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 # https://github.com/slackhq/circuit/releases
 # Note: circuit-codegen KSP processor is no longer needed; Metro provides built-in Circuit codegen
 # via enableCircuitCodegen. The circuit-codegen-annotations artifact is also added automatically.
+circuit-codegen-annotations = { group = "com.slack.circuit", name = "circuit-codegen-annotations", version.ref = "circuit" }
 circuit-foundation = { group = "com.slack.circuit", name = "circuit-foundation", version.ref = "circuit" }
 circuit-overlay = { group = "com.slack.circuit", name = "circuit-overlay", version.ref = "circuit" }
+circuit-serialization = { group = "com.slack.circuit", name = "circuit-serialization", version.ref = "circuit" }
 circuit-test = { group = "com.slack.circuit", name = "circuit-test", version.ref = "circuit" }
 circuitx-android = { group = "com.slack.circuit", name = "circuitx-android", version.ref = "circuit" }
 circuitx-effects = { group = "com.slack.circuit", name = "circuitx-effects", version.ref = "circuit" }


### PR DESCRIPTION
This PR migrates the project to leverage the new features introduced in [Circuit 0.36.0](https://github.com/slackhq/circuit/blob/HEAD/CHANGELOG.md#0360) (following dependency update in #441):

### Key Changes
- **Screen Serialization with `@CircuitSerializable`**:
  - Annotated `InboxScreen`, `DetailScreen`, and `ComposeEmailScreen` with `@Serializable` and `@CircuitSerializable(AppScope::class)`.
  - Metro automatically collects `CircuitSerializerRegistration` multibindings generated for these screens.
- **Pluggable `CircuitSaver`**:
  - Configured `SerializableCircuitSaver(serializerRegistrations)` on `Circuit.Builder` in `CircuitProviders.kt`.
- **First-party Compose Retention**:
  - Enabled `CircuitRetainedSettings.useFirstParty = true` in `MainActivity.onCreate()` to back retained state with Compose 1.11+ `retain` under the hood.
- **Dependencies**:
  - Added `circuit-serialization` and `circuit-codegen-annotations` to `libs.versions.toml` and `app/build.gradle.kts`.