### PR TITLE
Upgrade Metro DI to 1.4.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,7 @@ retrofitKotlinxSerializationConverter = "1.0.0"
 # https://github.com/pinterest/ktlint
 kotlinter = "5.6.0"
 lifecycleRuntimeKtx = "2.11.0"
-metro = "1.3.2"
+metro = "1.4.0"
 androidxWork = "2.11.2"
 
 [libraries]


### PR DESCRIPTION
Upgrades Metro DI plugin from `1.3.2` to `1.4.0` in `gradle/libs.versions.toml`.

### Metro 1.4.0 Feature Readiness Summary

- **`@CircuitSerializable` Auto-Set Contribution**:
  Metro 1.4.0 automatically generates `CircuitSerializerRegistration` Set contributions for `@CircuitSerializable` `Screen`s and `PopResult`s. Integrates seamlessly with `CircuitProviders.kt`.
- **Function Provider Syntax (`() -> T`)**:
  Leverages Metro's recommended `() -> T` function provider multibindings (e.g., `Map<KClass<out Activity>, () -> Activity>` in `AppGraph.kt`).
- **Built-in Circuit Codegen**:
  Configured via `metro { enableCircuitCodegen.set(true) }` in `app/build.gradle.kts`.
- **Rust-Style Graph Diagnostics**:
  Surfaces structured compiler error traces with diagnostic IDs (`[Metro/EmptyMultibinding]`), code pointers, and `help:` / `docs:` guidance.