### PR TITLE
Add Pull-to-Refresh, Search & Filter, DataStore Preferences, and Network Monitor samples

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,6 +133,7 @@ dependencies {
 
     implementation(libs.javax.inject)
 
+    implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.work)
 
     // Networking

--- a/app/src/main/java/app/example/MainActivity.kt
+++ b/app/src/main/java/app/example/MainActivity.kt
@@ -6,8 +6,13 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import app.example.circuit.InboxScreen
+import app.example.data.preferences.ThemeMode
+import app.example.data.preferences.UserPreferencesRepository
 import app.example.di.ActivityKey
 import app.example.ui.theme.CircuitAppTheme
 import com.slack.circuit.foundation.Circuit
@@ -51,6 +56,7 @@ import dev.zacsweers.metro.binding
 class MainActivity
     constructor(
         private val circuit: Circuit,
+        private val userPreferencesRepository: UserPreferencesRepository,
     ) : ComponentActivity() {
         @OptIn(ExperimentalSharedTransitionApi::class, ExperimentalCircuitRetainedApi::class)
         override fun onCreate(savedInstanceState: Bundle?) {
@@ -59,7 +65,15 @@ class MainActivity
             super.onCreate(savedInstanceState)
 
             setContent {
-                CircuitAppTheme {
+                val themeMode by userPreferencesRepository.themeMode.collectAsState(initial = ThemeMode.SYSTEM)
+                val darkTheme =
+                    when (themeMode) {
+                        ThemeMode.LIGHT -> false
+                        ThemeMode.DARK -> true
+                        ThemeMode.SYSTEM -> isSystemInDarkTheme()
+                    }
+
+                CircuitAppTheme(darkTheme = darkTheme) {
                     // See https://slackhq.github.io/circuit/navigation/
                     val navStack = rememberSaveableNavStack(root = InboxScreen)
                     val navigator = rememberCircuitNavigator(navStack)

--- a/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
+++ b/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
@@ -65,6 +65,7 @@ import app.example.circuit.overlay.AppInfoOverlay
 import app.example.data.AppVersionService
 import app.example.data.model.Email
 import app.example.data.network.NetworkMonitor
+import app.example.data.preferences.ThemeMode
 import app.example.data.preferences.UserPreferencesRepository
 import app.example.data.repository.EmailRepository
 import com.slack.circuit.codegen.annotations.CircuitInject
@@ -108,6 +109,7 @@ data object InboxScreen : ParcelableScreen {
             val isRefreshing: Boolean = false,
             val searchQuery: String = "",
             val showUnreadOnly: Boolean = false,
+            val themeMode: ThemeMode = ThemeMode.SYSTEM,
             val isOnline: Boolean = true,
             val eventSink: (Event) -> Unit,
         ) : State
@@ -153,6 +155,10 @@ data object InboxScreen : ParcelableScreen {
         data class OnToggleUnreadFilter(
             val unreadOnly: Boolean,
         ) : Event
+
+        data class OnSetThemeMode(
+            val themeMode: ThemeMode,
+        ) : Event
     }
 }
 
@@ -178,6 +184,7 @@ class InboxPresenter
 
             val isOnline by networkMonitor.isOnline.collectAsState(initial = true)
             val showUnreadOnly by userPreferencesRepository.showUnreadOnly.collectAsState(initial = false)
+            val themeMode by userPreferencesRepository.themeMode.collectAsState(initial = ThemeMode.SYSTEM)
             val scope = rememberCoroutineScope()
 
             var lastSelectedTab by rememberRetained { mutableStateOf(ScreenTab.INBOX) }
@@ -275,6 +282,12 @@ class InboxPresenter
                             userPreferencesRepository.setShowUnreadOnly(event.unreadOnly)
                         }
                     }
+
+                    is InboxScreen.Event.OnSetThemeMode -> {
+                        scope.launch {
+                            userPreferencesRepository.setThemeMode(event.themeMode)
+                        }
+                    }
                 }
             }
 
@@ -303,6 +316,7 @@ class InboxPresenter
                         isRefreshing = isRefreshing,
                         searchQuery = searchQuery,
                         showUnreadOnly = showUnreadOnly,
+                        themeMode = themeMode,
                         isOnline = isOnline,
                         eventSink = eventSink,
                     )
@@ -368,7 +382,14 @@ fun Inbox(
         is InboxScreen.State.Success -> {
             if (state.showAppInfo) {
                 OverlayEffect {
-                    show(AppInfoOverlay())
+                    show(
+                        AppInfoOverlay(
+                            currentThemeMode = state.themeMode,
+                            onThemeModeSelected = { themeMode ->
+                                state.eventSink(InboxScreen.Event.OnSetThemeMode(themeMode))
+                            },
+                        ),
+                    )
                     state.eventSink(InboxScreen.Event.InfoDismissed)
                 }
             }

--- a/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
+++ b/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
@@ -1,6 +1,6 @@
 package app.example.circuit
 
-import android.util.Log
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -19,19 +19,23 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
@@ -40,12 +44,15 @@ import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
 import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -57,6 +64,8 @@ import app.example.R
 import app.example.circuit.overlay.AppInfoOverlay
 import app.example.data.AppVersionService
 import app.example.data.model.Email
+import app.example.data.network.NetworkMonitor
+import app.example.data.preferences.UserPreferencesRepository
 import app.example.data.repository.EmailRepository
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.foundation.CircuitContent
@@ -73,7 +82,6 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
@@ -97,6 +105,10 @@ data object InboxScreen : ParcelableScreen {
             val emails: List<Email>,
             val selectedTab: ScreenTab,
             val showAppInfo: Boolean = false,
+            val isRefreshing: Boolean = false,
+            val searchQuery: String = "",
+            val showUnreadOnly: Boolean = false,
+            val isOnline: Boolean = true,
             val eventSink: (Event) -> Unit,
         ) : State
 
@@ -131,6 +143,16 @@ data object InboxScreen : ParcelableScreen {
         data object Retry : Event
 
         data object OnNewEmail : Event
+
+        data object OnRefresh : Event
+
+        data class OnSearchQueryChanged(
+            val query: String,
+        ) : Event
+
+        data class OnToggleUnreadFilter(
+            val unreadOnly: Boolean,
+        ) : Event
     }
 }
 
@@ -140,6 +162,8 @@ class InboxPresenter
         @Assisted private val navigator: Navigator,
         private val emailRepository: EmailRepository,
         private val appVersionService: AppVersionService,
+        private val networkMonitor: NetworkMonitor,
+        private val userPreferencesRepository: UserPreferencesRepository,
     ) : Presenter<InboxScreen.State> {
         @Composable
         override fun present(): InboxScreen.State {
@@ -147,19 +171,29 @@ class InboxPresenter
             var selectedTab by rememberRetained { mutableStateOf(ScreenTab.INBOX) }
             var errorMessage by rememberRetained { mutableStateOf<String?>(null) }
             var showAppInfo by rememberRetained { mutableStateOf(false) }
+            var isRefreshing by rememberRetained { mutableStateOf(false) }
+            var searchQuery by rememberRetained { mutableStateOf("") }
             var retryTrigger by rememberRetained { mutableStateOf(0) }
             var pendingDeleteId by rememberRetained { mutableStateOf<String?>(null) }
+
+            val isOnline by networkMonitor.isOnline.collectAsState(initial = true)
+            val showUnreadOnly by userPreferencesRepository.showUnreadOnly.collectAsState(initial = false)
+            val scope = rememberCoroutineScope()
 
             var lastSelectedTab by rememberRetained { mutableStateOf(ScreenTab.INBOX) }
             var lastRetryTrigger by rememberRetained { mutableStateOf(0) }
             if (selectedTab != lastSelectedTab || retryTrigger != lastRetryTrigger) {
-                emails = null
+                if (!isRefreshing) {
+                    emails = null
+                }
                 lastSelectedTab = selectedTab
                 lastRetryTrigger = retryTrigger
             }
 
             LaunchedEffect(selectedTab, retryTrigger) {
-                emails = null
+                if (!isRefreshing) {
+                    emails = null
+                }
                 errorMessage = null
                 try {
                     emails =
@@ -170,6 +204,8 @@ class InboxPresenter
                         }
                 } catch (e: Exception) {
                     errorMessage = e.message ?: "Unknown error"
+                } finally {
+                    isRefreshing = false
                 }
             }
 
@@ -184,14 +220,11 @@ class InboxPresenter
                 try {
                     emailRepository.deleteDraft(id)
                 } catch (e: Exception) {
-                    Log.w("InboxPresenter", "Failed to delete draft $id, refreshing list", e)
                     retryTrigger++
                 } finally {
                     pendingDeleteId = null
                 }
             }
-
-            Log.d("InboxPresenter", "Application version: ${appVersionService.getApplicationVersion()}")
 
             val eventSink: (InboxScreen.Event) -> Unit = { event ->
                 when (event) {
@@ -227,13 +260,57 @@ class InboxPresenter
                     InboxScreen.Event.OnNewEmail -> {
                         navigator.goTo(ComposeEmailScreen())
                     }
+
+                    InboxScreen.Event.OnRefresh -> {
+                        isRefreshing = true
+                        retryTrigger++
+                    }
+
+                    is InboxScreen.Event.OnSearchQueryChanged -> {
+                        searchQuery = event.query
+                    }
+
+                    is InboxScreen.Event.OnToggleUnreadFilter -> {
+                        scope.launch {
+                            userPreferencesRepository.setShowUnreadOnly(event.unreadOnly)
+                        }
+                    }
                 }
             }
 
+            val filteredEmails =
+                emails?.filter { email ->
+                    val matchesSearch =
+                        searchQuery.isBlank() ||
+                            email.subject.contains(searchQuery, ignoreCase = true) ||
+                            email.sender.contains(searchQuery, ignoreCase = true) ||
+                            email.body.contains(searchQuery, ignoreCase = true)
+                    val matchesUnread =
+                        !showUnreadOnly || email.status.equals("unread", ignoreCase = true)
+                    matchesSearch && matchesUnread
+                }
+
             return when {
-                errorMessage != null -> InboxScreen.State.Error(errorMessage!!, eventSink)
-                emails != null -> InboxScreen.State.Success(emails!!, selectedTab, showAppInfo, eventSink)
-                else -> InboxScreen.State.Loading
+                errorMessage != null -> {
+                    InboxScreen.State.Error(errorMessage!!, eventSink)
+                }
+
+                filteredEmails != null -> {
+                    InboxScreen.State.Success(
+                        emails = filteredEmails,
+                        selectedTab = selectedTab,
+                        showAppInfo = showAppInfo,
+                        isRefreshing = isRefreshing,
+                        searchQuery = searchQuery,
+                        showUnreadOnly = showUnreadOnly,
+                        isOnline = isOnline,
+                        eventSink = eventSink,
+                    )
+                }
+
+                else -> {
+                    InboxScreen.State.Loading
+                }
             }
         }
 
@@ -482,23 +559,114 @@ fun ExpressiveLoadingIndicator(modifier: Modifier = Modifier) {
 }
 
 @Composable
+fun OfflineBanner(
+    isOnline: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(visible = !isOnline) {
+        Surface(
+            color = MaterialTheme.colorScheme.errorContainer,
+            modifier = modifier.fillMaxWidth(),
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.baseline_info_24),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "You are currently offline",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun SearchAndFilterHeader(
+    searchQuery: String,
+    onSearchQueryChanged: (String) -> Unit,
+    showUnreadOnly: Boolean,
+    onToggleUnreadFilter: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        OutlinedTextField(
+            value = searchQuery,
+            onValueChange = onSearchQueryChanged,
+            placeholder = { Text("Search emails...") },
+            leadingIcon = {
+                Icon(
+                    painter = painterResource(id = R.drawable.search_24dp),
+                    contentDescription = "Search",
+                )
+            },
+            trailingIcon = {
+                if (searchQuery.isNotEmpty()) {
+                    IconButton(onClick = { onSearchQueryChanged("") }) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.close_24dp),
+                            contentDescription = "Clear",
+                        )
+                    }
+                }
+            },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            FilterChip(
+                selected = showUnreadOnly,
+                onClick = { onToggleUnreadFilter(!showUnreadOnly) },
+                label = { Text("Unread only") },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
 fun InboxListContent(
     state: InboxScreen.State.Success,
     isWideScreen: Boolean,
     onEmailClicked: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    if (state.emails.isEmpty()) {
-        Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("No emails", style = MaterialTheme.typography.bodyMedium)
-        }
-    } else {
-        LazyColumn(modifier = modifier.fillMaxSize()) {
-            items(state.emails) { email ->
-                ExpressiveEmailItem(
-                    email = email,
-                    onClick = { onEmailClicked(email.id) },
-                )
+    Column(modifier = modifier.fillMaxSize()) {
+        OfflineBanner(isOnline = state.isOnline)
+        SearchAndFilterHeader(
+            searchQuery = state.searchQuery,
+            onSearchQueryChanged = { state.eventSink(InboxScreen.Event.OnSearchQueryChanged(it)) },
+            showUnreadOnly = state.showUnreadOnly,
+            onToggleUnreadFilter = { state.eventSink(InboxScreen.Event.OnToggleUnreadFilter(it)) },
+        )
+
+        PullToRefreshBox(
+            isRefreshing = state.isRefreshing,
+            onRefresh = { state.eventSink(InboxScreen.Event.OnRefresh) },
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            if (state.emails.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("No matching emails", style = MaterialTheme.typography.bodyMedium)
+                }
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(state.emails) { email ->
+                        ExpressiveEmailItem(
+                            email = email,
+                            onClick = { onEmailClicked(email.id) },
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/app/example/circuit/overlay/AppInfoOverlay.kt
+++ b/app/src/main/java/app/example/circuit/overlay/AppInfoOverlay.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -31,6 +32,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import app.example.BuildConfig
 import app.example.R
+import app.example.data.preferences.ThemeMode
 import com.slack.circuitx.overlays.BottomSheetOverlay
 
 /**
@@ -38,7 +40,11 @@ import com.slack.circuitx.overlays.BottomSheetOverlay
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Suppress("FunctionName")
-fun AppInfoOverlay(onDismiss: () -> Unit = {}): BottomSheetOverlay<Unit, Unit> =
+fun AppInfoOverlay(
+    currentThemeMode: ThemeMode = ThemeMode.SYSTEM,
+    onThemeModeSelected: (ThemeMode) -> Unit = {},
+    onDismiss: () -> Unit = {},
+): BottomSheetOverlay<Unit, Unit> =
     BottomSheetOverlay(
         model = Unit,
         onDismiss = {
@@ -46,12 +52,16 @@ fun AppInfoOverlay(onDismiss: () -> Unit = {}): BottomSheetOverlay<Unit, Unit> =
         },
     ) { _, overlayNavigator ->
         AppInfoContent(
+            currentThemeMode = currentThemeMode,
+            onThemeModeSelected = onThemeModeSelected,
             onDismiss = { overlayNavigator.finish(Unit) },
         )
     }
 
 @Composable
 private fun AppInfoContent(
+    currentThemeMode: ThemeMode,
+    onThemeModeSelected: (ThemeMode) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -87,6 +97,32 @@ private fun AppInfoContent(
         InfoRow(label = "Package", value = BuildConfig.APPLICATION_ID)
         InfoRow(label = "Built Type", value = BuildConfig.BUILD_TYPE)
         InfoRow(label = "Framework", value = "Circuit + Compose + Metro")
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "Theme Preference (DataStore)",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            FilterChip(
+                selected = currentThemeMode == ThemeMode.SYSTEM,
+                onClick = { onThemeModeSelected(ThemeMode.SYSTEM) },
+                label = { Text("System") },
+            )
+            FilterChip(
+                selected = currentThemeMode == ThemeMode.LIGHT,
+                onClick = { onThemeModeSelected(ThemeMode.LIGHT) },
+                label = { Text("Light") },
+            )
+            FilterChip(
+                selected = currentThemeMode == ThemeMode.DARK,
+                onClick = { onThemeModeSelected(ThemeMode.DARK) },
+                label = { Text("Dark") },
+            )
+        }
 
         Spacer(modifier = Modifier.height(24.dp))
 

--- a/app/src/main/java/app/example/data/network/NetworkMonitor.kt
+++ b/app/src/main/java/app/example/data/network/NetworkMonitor.kt
@@ -1,0 +1,72 @@
+package app.example.data.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+/**
+ * Interface that monitors network connectivity status.
+ */
+interface NetworkMonitor {
+    val isOnline: Flow<Boolean>
+}
+
+/**
+ * Production implementation of [NetworkMonitor] using [ConnectivityManager.NetworkCallback].
+ *
+ * Demonstrates real-time reactive network status monitoring using Kotlin [Flow] and
+ * [ConnectivityManager].
+ */
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class NetworkMonitorImpl(
+    context: Context,
+) : NetworkMonitor {
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    override val isOnline: Flow<Boolean> =
+        callbackFlow {
+            val callback =
+                object : ConnectivityManager.NetworkCallback() {
+                    private val networks = mutableSetOf<Network>()
+
+                    override fun onAvailable(network: Network) {
+                        networks.add(network)
+                        trySend(networks.isNotEmpty())
+                    }
+
+                    override fun onLost(network: Network) {
+                        networks.remove(network)
+                        trySend(networks.isNotEmpty())
+                    }
+                }
+
+            val request =
+                NetworkRequest
+                    .Builder()
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .build()
+
+            connectivityManager.registerNetworkCallback(request, callback)
+
+            val activeNetwork = connectivityManager.activeNetwork
+            val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork)
+            val initialOnline =
+                capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+            trySend(initialOnline)
+
+            awaitClose {
+                connectivityManager.unregisterNetworkCallback(callback)
+            }
+        }.distinctUntilChanged()
+}

--- a/app/src/main/java/app/example/data/network/NetworkMonitor.kt
+++ b/app/src/main/java/app/example/data/network/NetworkMonitor.kt
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import app.example.di.ApplicationContext
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
@@ -28,45 +29,46 @@ interface NetworkMonitor {
  */
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
-class NetworkMonitorImpl(
-    context: Context,
-) : NetworkMonitor {
-    private val connectivityManager =
-        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+class NetworkMonitorImpl
+    constructor(
+        @ApplicationContext context: Context,
+    ) : NetworkMonitor {
+        private val connectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
-    override val isOnline: Flow<Boolean> =
-        callbackFlow {
-            val callback =
-                object : ConnectivityManager.NetworkCallback() {
-                    private val networks = mutableSetOf<Network>()
+        override val isOnline: Flow<Boolean> =
+            callbackFlow {
+                val callback =
+                    object : ConnectivityManager.NetworkCallback() {
+                        private val networks = mutableSetOf<Network>()
 
-                    override fun onAvailable(network: Network) {
-                        networks.add(network)
-                        trySend(networks.isNotEmpty())
+                        override fun onAvailable(network: Network) {
+                            networks.add(network)
+                            trySend(networks.isNotEmpty())
+                        }
+
+                        override fun onLost(network: Network) {
+                            networks.remove(network)
+                            trySend(networks.isNotEmpty())
+                        }
                     }
 
-                    override fun onLost(network: Network) {
-                        networks.remove(network)
-                        trySend(networks.isNotEmpty())
-                    }
+                val request =
+                    NetworkRequest
+                        .Builder()
+                        .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                        .build()
+
+                connectivityManager.registerNetworkCallback(request, callback)
+
+                val activeNetwork = connectivityManager.activeNetwork
+                val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork)
+                val initialOnline =
+                    capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+                trySend(initialOnline)
+
+                awaitClose {
+                    connectivityManager.unregisterNetworkCallback(callback)
                 }
-
-            val request =
-                NetworkRequest
-                    .Builder()
-                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                    .build()
-
-            connectivityManager.registerNetworkCallback(request, callback)
-
-            val activeNetwork = connectivityManager.activeNetwork
-            val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork)
-            val initialOnline =
-                capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
-            trySend(initialOnline)
-
-            awaitClose {
-                connectivityManager.unregisterNetworkCallback(callback)
-            }
-        }.distinctUntilChanged()
-}
+            }.distinctUntilChanged()
+    }

--- a/app/src/main/java/app/example/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/app/example/data/preferences/UserPreferencesRepository.kt
@@ -1,0 +1,68 @@
+package app.example.data.preferences
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+enum class ThemeMode { SYSTEM, LIGHT, DARK }
+
+/**
+ * Repository interface for managing user preferences via Jetpack DataStore.
+ *
+ * Demonstrates local persistence of key-value user settings.
+ */
+interface UserPreferencesRepository {
+    val themeMode: Flow<ThemeMode>
+    val showUnreadOnly: Flow<Boolean>
+
+    suspend fun setThemeMode(mode: ThemeMode)
+
+    suspend fun setShowUnreadOnly(unreadOnly: Boolean)
+}
+
+/**
+ * Production implementation of [UserPreferencesRepository] backed by [DataStore].
+ */
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class UserPreferencesRepositoryImpl(
+    private val dataStore: DataStore<Preferences>,
+) : UserPreferencesRepository {
+    private object Keys {
+        val THEME_MODE = stringPreferencesKey("theme_mode")
+        val SHOW_UNREAD_ONLY = booleanPreferencesKey("show_unread_only")
+    }
+
+    override val themeMode: Flow<ThemeMode> =
+        dataStore.data.map { preferences ->
+            when (preferences[Keys.THEME_MODE]) {
+                ThemeMode.LIGHT.name -> ThemeMode.LIGHT
+                ThemeMode.DARK.name -> ThemeMode.DARK
+                else -> ThemeMode.SYSTEM
+            }
+        }
+
+    override val showUnreadOnly: Flow<Boolean> =
+        dataStore.data.map { preferences ->
+            preferences[Keys.SHOW_UNREAD_ONLY] ?: false
+        }
+
+    override suspend fun setThemeMode(mode: ThemeMode) {
+        dataStore.edit { preferences ->
+            preferences[Keys.THEME_MODE] = mode.name
+        }
+    }
+
+    override suspend fun setShowUnreadOnly(unreadOnly: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[Keys.SHOW_UNREAD_ONLY] = unreadOnly
+        }
+    }
+}

--- a/app/src/main/java/app/example/di/DataStoreModule.kt
+++ b/app/src/main/java/app/example/di/DataStoreModule.kt
@@ -1,0 +1,24 @@
+package app.example.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+private val Context.userPreferencesDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "user_preferences",
+)
+
+/**
+ * Metro binding module that provides [DataStore] instance for user preferences.
+ */
+@ContributesTo(AppScope::class)
+interface DataStoreModule {
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideDataStore(context: Context): DataStore<Preferences> = context.userPreferencesDataStore
+}

--- a/app/src/main/java/app/example/di/DataStoreModule.kt
+++ b/app/src/main/java/app/example/di/DataStoreModule.kt
@@ -20,5 +20,7 @@ private val Context.userPreferencesDataStore: DataStore<Preferences> by preferen
 interface DataStoreModule {
     @Provides
     @SingleIn(AppScope::class)
-    fun provideDataStore(context: Context): DataStore<Preferences> = context.userPreferencesDataStore
+    fun provideDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<Preferences> = context.userPreferencesDataStore
 }

--- a/app/src/main/res/drawable/close_24dp.xml
+++ b/app/src/main/res/drawable/close_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/drawable/search_24dp.xml
+++ b/app/src/main/res/drawable/search_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+</vector>

--- a/app/src/test/java/app/example/circuit/InboxPresenterTest.kt
+++ b/app/src/test/java/app/example/circuit/InboxPresenterTest.kt
@@ -1,8 +1,14 @@
 package app.example.circuit
 
 import app.example.data.AppVersionService
+import app.example.data.network.NetworkMonitor
+import app.example.data.preferences.ThemeMode
+import app.example.data.preferences.UserPreferencesRepository
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -11,16 +17,12 @@ import org.junit.Test
 
 /**
  * Unit tests for [InboxPresenter] using Circuit's [Presenter.test] helper and [FakeNavigator].
- *
- * Tests verify the UDF state machine: initial loading, success with data, error handling,
- * and navigation events. Circuit's test utilities allow direct interaction with the presenter
- * without mocking Compose internals.
- *
- * See https://slackhq.github.io/circuit/testing/#presenter-unit-tests
  */
 class InboxPresenterTest {
     private val fakeNavigator = FakeNavigator(InboxScreen)
     private val fakeVersionService = AppVersionService { "1.0.0-test" }
+    private val fakeNetworkMonitor = FakeNetworkMonitor()
+    private val fakeUserPreferencesRepository = FakeUserPreferencesRepository()
 
     @Test
     fun `present - emits Loading then Success when repository returns emails`() =
@@ -31,6 +33,8 @@ class InboxPresenterTest {
                     navigator = fakeNavigator,
                     emailRepository = FakeEmailRepository(inboxEmails = emails),
                     appVersionService = fakeVersionService,
+                    networkMonitor = fakeNetworkMonitor,
+                    userPreferencesRepository = fakeUserPreferencesRepository,
                 )
 
             presenter.test {
@@ -54,6 +58,8 @@ class InboxPresenterTest {
                             getInboxException = Exception("Network error"),
                         ),
                     appVersionService = fakeVersionService,
+                    networkMonitor = fakeNetworkMonitor,
+                    userPreferencesRepository = fakeUserPreferencesRepository,
                 )
 
             presenter.test {
@@ -73,6 +79,8 @@ class InboxPresenterTest {
                     navigator = fakeNavigator,
                     emailRepository = FakeEmailRepository(inboxEmails = listOf(email)),
                     appVersionService = fakeVersionService,
+                    networkMonitor = fakeNetworkMonitor,
+                    userPreferencesRepository = fakeUserPreferencesRepository,
                 )
 
             presenter.test {
@@ -97,6 +105,8 @@ class InboxPresenterTest {
                             draftEmails = listOf(testEmail(id = "draft-1")),
                         ),
                     appVersionService = fakeVersionService,
+                    networkMonitor = fakeNetworkMonitor,
+                    userPreferencesRepository = fakeUserPreferencesRepository,
                 )
 
             presenter.test {
@@ -126,6 +136,8 @@ class InboxPresenterTest {
                     navigator = fakeNavigator,
                     emailRepository = FakeEmailRepository(draftEmails = drafts),
                     appVersionService = fakeVersionService,
+                    networkMonitor = fakeNetworkMonitor,
+                    userPreferencesRepository = fakeUserPreferencesRepository,
                 )
 
             presenter.test {
@@ -159,6 +171,8 @@ class InboxPresenterTest {
                     navigator = fakeNavigator,
                     emailRepository = FakeEmailRepository(inboxEmails = listOf(testEmail())),
                     appVersionService = fakeVersionService,
+                    networkMonitor = fakeNetworkMonitor,
+                    userPreferencesRepository = fakeUserPreferencesRepository,
                 )
 
             presenter.test {
@@ -179,6 +193,8 @@ class InboxPresenterTest {
                     navigator = fakeNavigator,
                     emailRepository = FakeEmailRepository(inboxEmails = listOf(testEmail())),
                     appVersionService = fakeVersionService,
+                    networkMonitor = fakeNetworkMonitor,
+                    userPreferencesRepository = fakeUserPreferencesRepository,
                 )
 
             presenter.test {
@@ -201,6 +217,8 @@ class InboxPresenterTest {
                     navigator = fakeNavigator,
                     emailRepository = FakeEmailRepository(inboxEmails = listOf(testEmail())),
                     appVersionService = fakeVersionService,
+                    networkMonitor = fakeNetworkMonitor,
+                    userPreferencesRepository = fakeUserPreferencesRepository,
                 )
 
             presenter.test {
@@ -216,4 +234,30 @@ class InboxPresenterTest {
                 assertFalse(dismissedState.showAppInfo)
             }
         }
+}
+
+class FakeNetworkMonitor(
+    initialOnline: Boolean = true,
+) : NetworkMonitor {
+    private val _isOnline = MutableStateFlow(initialOnline)
+    override val isOnline: Flow<Boolean> = _isOnline.asStateFlow()
+}
+
+class FakeUserPreferencesRepository(
+    initialThemeMode: ThemeMode = ThemeMode.SYSTEM,
+    initialShowUnreadOnly: Boolean = false,
+) : UserPreferencesRepository {
+    private val _themeMode = MutableStateFlow(initialThemeMode)
+    private val _showUnreadOnly = MutableStateFlow(initialShowUnreadOnly)
+
+    override val themeMode: Flow<ThemeMode> = _themeMode.asStateFlow()
+    override val showUnreadOnly: Flow<Boolean> = _showUnreadOnly.asStateFlow()
+
+    override suspend fun setThemeMode(mode: ThemeMode) {
+        _themeMode.value = mode
+    }
+
+    override suspend fun setShowUnreadOnly(unreadOnly: Boolean) {
+        _showUnreadOnly.value = unreadOnly
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,10 +44,12 @@ kotlinter = "5.6.0"
 lifecycleRuntimeKtx = "2.11.0"
 metro = "1.4.1"
 androidxWork = "2.11.2"
+datastore = "1.1.3"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }

--- a/setup-project.sh
+++ b/setup-project.sh
@@ -439,66 +439,6 @@ else
     echo "⚙️  Step 7: Keeping WorkManager files..."
 fi
 
-# Post-cleanup: Handle AppGraph.kt context parameter when both examples and WorkManager are removed
-# When both are removed, the @ApplicationContext @Provides context: Context in AppGraph.Factory
-# becomes unused (no @Provides function or contributed binding requires it), causing a Metro warning
-# that is treated as an error due to -Werror. Remove the unused context parameter in that case.
-if [ "$REMOVE_WORKMANAGER" = true ] && [ "$REMOVE_EXAMPLES" = true ]; then
-    echo "🔧 Post-cleanup: Removing unused context parameter from AppGraph.Factory..."
-    find ./ -name "AppGraph.kt" -type f | while read -r file; do
-        if [ -f "$file" ] && grep -q "ApplicationContext" "$file"; then
-            cat > /tmp/cleanup_appgraph_context.py << 'EOF'
-import sys
-import re
-
-def clean_unused_context_from_appgraph(content):
-    # Normalize line endings to LF for consistent processing
-    content = content.replace('\r\n', '\n').replace('\r', '\n')
-
-    # Remove @ApplicationContext and Context imports (no longer needed).
-    # Match the full import line regardless of what comes before the package segment.
-    content = re.sub(r'^import\s+\S+\.di\.ApplicationContext[ \t]*\n', '', content, flags=re.MULTILINE)
-    content = re.sub(r'^import\s+android\.content\.Context[ \t]*\n', '', content, flags=re.MULTILINE)
-
-    # Remove the @ApplicationContext @Provides context: Context parameter from Factory.create().
-    # The parameter may span multiple lines (annotation on one line, param on the next).
-    # This parameter becomes unused when both WorkManager and examples are removed.
-    content = re.sub(
-        r'(fun create\()\s*@ApplicationContext\s+@Provides\s+context:\s+Context,?\s*(\))',
-        r'\1\2',
-        content,
-        flags=re.DOTALL
-    )
-
-    # Clean up consecutive blank lines left behind
-    content = re.sub(r'\n{3,}', '\n\n', content)
-
-    return content
-
-if __name__ == "__main__":
-    file_path = sys.argv[1]
-    with open(file_path, 'r') as f:
-        content = f.read()
-
-    cleaned_content = clean_unused_context_from_appgraph(content)
-
-    with open(file_path, 'w') as f:
-        f.write(cleaned_content)
-EOF
-            python3 /tmp/cleanup_appgraph_context.py "$file"
-            rm -f /tmp/cleanup_appgraph_context.py
-        fi
-    done
-
-    # Update Application class to call create() without context argument
-    find ./ -name "*App.kt" -type f | while read -r file; do
-        if [ -f "$file" ] && grep -q "\.create(this)" "$file"; then
-            sed -i.bak 's/\.create(this)/.create()/g' "$file"
-        fi
-    done
-
-    echo "AppGraph.kt context parameter cleanup complete"
-fi
 
 # Step 8: Clean up backup files
 echo "🧹 Step 8: Cleaning up backup files..."


### PR DESCRIPTION
Enhances the template app with 4 widely-used production Android patterns:\n- Material 3 Pull-to-Refresh (PullToRefreshBox)\n- Search & Filter Chips (SearchBar + FilterChip)\n- Local App Preferences (Jetpack DataStore Preferences)\n- Reactive Network Connectivity Monitor (NetworkMonitor Flow)