### PR TITLE
Integrate PATCH /api/emails/{emailId}/read endpoint for email read status

### DIFF
--- a/app/src/main/java/app/example/circuit/ExampleEmailDetailsScreen.kt
+++ b/app/src/main/java/app/example/circuit/ExampleEmailDetailsScreen.kt
@@ -119,9 +119,15 @@ class DetailPresenter
                 email = null
                 errorMessage = null
                 try {
-                    email = emailRepository.getEmail(screen.emailId)
-                    if (email == null) {
+                    val loadedEmail = emailRepository.getEmail(screen.emailId)
+                    email = loadedEmail
+                    if (loadedEmail == null) {
                         errorMessage = "Email not found"
+                    } else if (!loadedEmail.isRead) {
+                        try {
+                            email = emailRepository.updateEmailReadStatus(screen.emailId, isRead = true)
+                        } catch (_: Exception) {
+                        }
                     }
                 } catch (e: Exception) {
                     errorMessage = e.message ?: "Unknown error"

--- a/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
+++ b/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
@@ -159,6 +159,11 @@ data object InboxScreen : ParcelableScreen {
         data class OnSetThemeMode(
             val themeMode: ThemeMode,
         ) : Event
+
+        data class OnToggleReadStatus(
+            val emailId: String,
+            val isRead: Boolean? = null,
+        ) : Event
     }
 }
 
@@ -236,6 +241,12 @@ class InboxPresenter
             val eventSink: (InboxScreen.Event) -> Unit = { event ->
                 when (event) {
                     is InboxScreen.Event.EmailClicked -> {
+                        scope.launch {
+                            try {
+                                emailRepository.updateEmailReadStatus(event.emailId, isRead = true)
+                            } catch (_: Exception) {
+                            }
+                        }
                         navigator.goTo(DetailScreen(event.emailId))
                     }
 
@@ -286,6 +297,15 @@ class InboxPresenter
                     is InboxScreen.Event.OnSetThemeMode -> {
                         scope.launch {
                             userPreferencesRepository.setThemeMode(event.themeMode)
+                        }
+                    }
+
+                    is InboxScreen.Event.OnToggleReadStatus -> {
+                        scope.launch {
+                            try {
+                                emailRepository.updateEmailReadStatus(event.emailId, event.isRead)
+                            } catch (_: Exception) {
+                            }
                         }
                     }
                 }
@@ -765,13 +785,24 @@ fun ExpressiveEmailItem(
                     Modifier
                         .size(40.dp)
                         .clip(androidx.compose.foundation.shape.CircleShape)
-                        .background(MaterialTheme.colorScheme.primaryContainer),
+                        .background(
+                            if (!email.isRead) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.primaryContainer
+                            },
+                        ),
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
                     text = email.sender.take(1).uppercase(),
                     style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    color =
+                        if (!email.isRead) {
+                            MaterialTheme.colorScheme.onPrimary
+                        } else {
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        },
                 )
             }
 
@@ -781,14 +812,33 @@ fun ExpressiveEmailItem(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(
-                        text = email.sender,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-                        maxLines = 1,
-                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                    Row(
                         modifier = Modifier.weight(1f),
-                    )
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        if (!email.isRead) {
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .size(8.dp)
+                                        .clip(androidx.compose.foundation.shape.CircleShape)
+                                        .background(MaterialTheme.colorScheme.primary),
+                            )
+                        }
+                        Text(
+                            text = email.sender,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight =
+                                if (!email.isRead) {
+                                    androidx.compose.ui.text.font.FontWeight.Bold
+                                } else {
+                                    androidx.compose.ui.text.font.FontWeight.Medium
+                                },
+                            maxLines = 1,
+                            overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                        )
+                    }
                     Text(
                         text = email.timestamp,
                         style = MaterialTheme.typography.bodySmall,
@@ -799,7 +849,12 @@ fun ExpressiveEmailItem(
                 Text(
                     text = email.subject,
                     style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
+                    fontWeight =
+                        if (!email.isRead) {
+                            androidx.compose.ui.text.font.FontWeight.Bold
+                        } else {
+                            androidx.compose.ui.text.font.FontWeight.Normal
+                        },
                     maxLines = 1,
                     overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                 )

--- a/app/src/main/java/app/example/data/model/Email.kt
+++ b/app/src/main/java/app/example/data/model/Email.kt
@@ -24,4 +24,5 @@ data class Email(
     val recipients: List<String>,
     val timestamp: String,
     val status: String,
+    val isRead: Boolean = false,
 )

--- a/app/src/main/java/app/example/data/network/EmailApiService.kt
+++ b/app/src/main/java/app/example/data/network/EmailApiService.kt
@@ -5,9 +5,11 @@ import app.example.data.network.dto.DeleteEmailResponse
 import app.example.data.network.dto.EmailListResponse
 import app.example.data.network.dto.SendEmailRequest
 import app.example.data.network.dto.SingleEmailResponse
+import app.example.data.network.dto.UpdateReadStatusRequest
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -74,4 +76,16 @@ interface EmailApiService {
     suspend fun deleteEmail(
         @Path("emailId") emailId: String,
     ): DeleteEmailResponse
+
+    /**
+     * Toggle or explicitly set email read status.
+     *
+     * @param emailId The UUID of the email.
+     * @param request Optional request body containing explicit read state. Inverts state if null.
+     */
+    @PATCH("api/emails/{emailId}/read")
+    suspend fun updateEmailReadStatus(
+        @Path("emailId") emailId: String,
+        @Body request: UpdateReadStatusRequest? = null,
+    ): SingleEmailResponse
 }

--- a/app/src/main/java/app/example/data/network/dto/EmailResponse.kt
+++ b/app/src/main/java/app/example/data/network/dto/EmailResponse.kt
@@ -19,6 +19,13 @@ data class EmailDto(
     val recipients: List<String>,
     val timestamp: String,
     val status: String,
+    val isRead: Boolean? = false,
+)
+
+/** Request payload for toggling or setting email read status. */
+@Serializable
+data class UpdateReadStatusRequest(
+    val isRead: Boolean? = null,
 )
 
 /** API response wrapper for a list of emails (used for inbox and drafts). */
@@ -55,6 +62,7 @@ fun EmailDto.toDomain(): Email =
         recipients = recipients,
         timestamp = formatTimestamp(timestamp),
         status = status,
+        isRead = isRead ?: false,
     )
 
 /** Formats ISO 8601 timestamps (e.g. 2026-07-18T21:33:17.000Z) into readable dates (e.g. Jul 18). */

--- a/app/src/main/java/app/example/data/repository/EmailRepository.kt
+++ b/app/src/main/java/app/example/data/repository/EmailRepository.kt
@@ -89,4 +89,17 @@ interface EmailRepository {
      * @throws Exception if the network request fails.
      */
     suspend fun deleteDraft(draftId: String): Boolean
+
+    /**
+     * Toggles or sets the read status of an email.
+     *
+     * @param emailId The UUID of the email.
+     * @param isRead Optional explicit read state. Inverts state if null.
+     * @return The updated [Email] domain model.
+     * @throws Exception if the network request fails.
+     */
+    suspend fun updateEmailReadStatus(
+        emailId: String,
+        isRead: Boolean? = null,
+    ): Email
 }

--- a/app/src/main/java/app/example/data/repository/EmailRepositoryImpl.kt
+++ b/app/src/main/java/app/example/data/repository/EmailRepositoryImpl.kt
@@ -139,4 +139,26 @@ class EmailRepositoryImpl
             }
             return response.success
         }
+
+        /**
+         * Toggles or sets the read status of an email via the API and updates the local cache.
+         */
+        override suspend fun updateEmailReadStatus(
+            emailId: String,
+            isRead: Boolean?,
+        ): Email {
+            val response =
+                apiService.updateEmailReadStatus(
+                    emailId = emailId,
+                    request =
+                        app.example.data.network.dto
+                            .UpdateReadStatusRequest(isRead),
+                )
+            val updatedEmail = response.data.toDomain()
+            cachedEmails = cachedEmails?.map { if (it.id == emailId) updatedEmail else it }
+            cachedDraftEmails = cachedDraftEmails?.map { if (it.id == emailId) updatedEmail else it }
+            cachedSentEmails = cachedSentEmails?.map { if (it.id == emailId) updatedEmail else it }
+            _updates.tryEmit(Unit)
+            return updatedEmail
+        }
     }

--- a/app/src/main/java/app/example/data/repository/EmailRepositoryImpl.kt
+++ b/app/src/main/java/app/example/data/repository/EmailRepositoryImpl.kt
@@ -4,6 +4,7 @@ import app.example.data.model.Email
 import app.example.data.network.EmailApiService
 import app.example.data.network.dto.CreateDraftRequest
 import app.example.data.network.dto.SendEmailRequest
+import app.example.data.network.dto.UpdateReadStatusRequest
 import app.example.data.network.dto.toDomain
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -150,9 +151,7 @@ class EmailRepositoryImpl
             val response =
                 apiService.updateEmailReadStatus(
                     emailId = emailId,
-                    request =
-                        app.example.data.network.dto
-                            .UpdateReadStatusRequest(isRead),
+                    request = UpdateReadStatusRequest(isRead),
                 )
             val updatedEmail = response.data.toDomain()
             cachedEmails = cachedEmails?.map { if (it.id == emailId) updatedEmail else it }

--- a/app/src/test/java/app/example/circuit/DetailPresenterTest.kt
+++ b/app/src/test/java/app/example/circuit/DetailPresenterTest.kt
@@ -24,7 +24,7 @@ class DetailPresenterTest {
     @Test
     fun `present - emits Loading then Success when email is found`() =
         runTest {
-            val email = testEmail(id = "email-1", subject = "Hello World")
+            val email = testEmail(id = "email-1", subject = "Hello World", isRead = true)
             val presenter =
                 DetailPresenter(
                     navigator = fakeNavigator,
@@ -85,7 +85,7 @@ class DetailPresenterTest {
     @Test
     fun `present - BackClicked event pops the back stack`() =
         runTest {
-            val email = testEmail(id = "email-1")
+            val email = testEmail(id = "email-1", isRead = true)
             val presenter =
                 DetailPresenter(
                     navigator = fakeNavigator,

--- a/app/src/test/java/app/example/circuit/FakeEmailRepository.kt
+++ b/app/src/test/java/app/example/circuit/FakeEmailRepository.kt
@@ -57,6 +57,19 @@ class FakeEmailRepository(
     ): Email = testEmail(id = "draft-1", subject = subject, body = body, status = "draft")
 
     override suspend fun deleteDraft(draftId: String): Boolean = true
+
+    override suspend fun updateEmailReadStatus(
+        emailId: String,
+        isRead: Boolean?,
+    ): Email {
+        val target =
+            inboxEmails.find { it.id == emailId }
+                ?: draftEmails.find { it.id == emailId }
+                ?: sentEmails.find { it.id == emailId }
+                ?: testEmail(id = emailId)
+        val newReadState = isRead ?: !target.isRead
+        return target.copy(isRead = newReadState)
+    }
 }
 
 /** Convenience factory for creating [Email] instances in tests. */
@@ -69,6 +82,7 @@ fun testEmail(
     recipients: List<String> = listOf("recipient@example.com"),
     timestamp: String = "12:00 PM",
     status: String = "inbox",
+    isRead: Boolean = false,
 ): Email =
     Email(
         id = id,
@@ -79,4 +93,5 @@ fun testEmail(
         recipients = recipients,
         timestamp = timestamp,
         status = status,
+        isRead = isRead,
     )

--- a/app/src/test/java/app/example/circuit/InboxPresenterTest.kt
+++ b/app/src/test/java/app/example/circuit/InboxPresenterTest.kt
@@ -234,6 +234,27 @@ class InboxPresenterTest {
                 assertFalse(dismissedState.showAppInfo)
             }
         }
+
+    @Test
+    fun `present - OnToggleReadStatus event triggers repository update`() =
+        runTest {
+            val presenter =
+                InboxPresenter(
+                    navigator = fakeNavigator,
+                    emailRepository = FakeEmailRepository(inboxEmails = listOf(testEmail(id = "1", isRead = false))),
+                    appVersionService = fakeVersionService,
+                    networkMonitor = fakeNetworkMonitor,
+                    userPreferencesRepository = fakeUserPreferencesRepository,
+                )
+
+            presenter.test {
+                assertEquals(InboxScreen.State.Loading, awaitItem())
+                val successState = awaitItem() as InboxScreen.State.Success
+
+                successState.eventSink(InboxScreen.Event.OnToggleReadStatus("1", isRead = true))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 }
 
 class FakeNetworkMonitor(


### PR DESCRIPTION
Integrates the new OpenAPI endpoint for marking emails as read/unread.