### PR TITLE
Add Reset Demo Emails button in App Information overlay

### DIFF
--- a/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
+++ b/app/src/main/java/app/example/circuit/ExampleInboxScreen.kt
@@ -164,6 +164,8 @@ data object InboxScreen : ParcelableScreen {
             val emailId: String,
             val isRead: Boolean? = null,
         ) : Event
+
+        data object OnResetDemoData : Event
     }
 }
 
@@ -308,6 +310,15 @@ class InboxPresenter
                             }
                         }
                     }
+
+                    InboxScreen.Event.OnResetDemoData -> {
+                        scope.launch {
+                            try {
+                                emailRepository.resetDemoData()
+                            } catch (_: Exception) {
+                            }
+                        }
+                    }
                 }
             }
 
@@ -407,6 +418,9 @@ fun Inbox(
                             currentThemeMode = state.themeMode,
                             onThemeModeSelected = { themeMode ->
                                 state.eventSink(InboxScreen.Event.OnSetThemeMode(themeMode))
+                            },
+                            onResetDemoData = {
+                                state.eventSink(InboxScreen.Event.OnResetDemoData)
                             },
                         ),
                     )

--- a/app/src/main/java/app/example/circuit/overlay/AppInfoOverlay.kt
+++ b/app/src/main/java/app/example/circuit/overlay/AppInfoOverlay.kt
@@ -43,6 +43,7 @@ import com.slack.circuitx.overlays.BottomSheetOverlay
 fun AppInfoOverlay(
     currentThemeMode: ThemeMode = ThemeMode.SYSTEM,
     onThemeModeSelected: (ThemeMode) -> Unit = {},
+    onResetDemoData: () -> Unit = {},
     onDismiss: () -> Unit = {},
 ): BottomSheetOverlay<Unit, Unit> =
     BottomSheetOverlay(
@@ -54,6 +55,7 @@ fun AppInfoOverlay(
         AppInfoContent(
             currentThemeMode = currentThemeMode,
             onThemeModeSelected = onThemeModeSelected,
+            onResetDemoData = onResetDemoData,
             onDismiss = { overlayNavigator.finish(Unit) },
         )
     }
@@ -62,6 +64,7 @@ fun AppInfoOverlay(
 private fun AppInfoContent(
     currentThemeMode: ThemeMode,
     onThemeModeSelected: (ThemeMode) -> Unit,
+    onResetDemoData: () -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -124,7 +127,19 @@ private fun AppInfoContent(
             )
         }
 
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(20.dp))
+
+        androidx.compose.material3.OutlinedButton(
+            onClick = {
+                onResetDemoData()
+                onDismiss()
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Reset Demo Emails")
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
 
         Button(
             onClick = onDismiss,

--- a/app/src/main/java/app/example/data/network/EmailApiService.kt
+++ b/app/src/main/java/app/example/data/network/EmailApiService.kt
@@ -5,6 +5,7 @@ import app.example.data.network.dto.DeleteEmailResponse
 import app.example.data.network.dto.EmailListResponse
 import app.example.data.network.dto.SendEmailRequest
 import app.example.data.network.dto.SingleEmailResponse
+import app.example.data.network.dto.SystemResetResponse
 import app.example.data.network.dto.UpdateReadStatusRequest
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -88,4 +89,10 @@ interface EmailApiService {
         @Path("emailId") emailId: String,
         @Body request: UpdateReadStatusRequest? = null,
     ): SingleEmailResponse
+
+    /**
+     * Manually trigger a data reset and re-seed the backend with demo data.
+     */
+    @POST("api/system/reset")
+    suspend fun resetSystemData(): SystemResetResponse
 }

--- a/app/src/main/java/app/example/data/network/dto/SystemResetResponse.kt
+++ b/app/src/main/java/app/example/data/network/dto/SystemResetResponse.kt
@@ -1,0 +1,23 @@
+package app.example.data.network.dto
+
+import kotlinx.serialization.Serializable
+
+/**
+ * API response wrapper for the system reset endpoint (POST /api/system/reset).
+ */
+@Serializable
+data class SystemResetResponse(
+    val success: Boolean,
+    val data: ResetData? = null,
+)
+
+/** Detail breakdown of re-seeded demo emails after reset. */
+@Serializable
+data class ResetData(
+    val message: String? = null,
+    val timestamp: Long? = null,
+    val emailsSeeded: Int? = null,
+    val inbox: Int? = null,
+    val drafts: Int? = null,
+    val sent: Int? = null,
+)

--- a/app/src/main/java/app/example/data/repository/EmailRepository.kt
+++ b/app/src/main/java/app/example/data/repository/EmailRepository.kt
@@ -102,4 +102,12 @@ interface EmailRepository {
         emailId: String,
         isRead: Boolean? = null,
     ): Email
+
+    /**
+     * Resets system demo data on the server to default seeded emails.
+     *
+     * @return `true` if the reset succeeded.
+     * @throws Exception if the network request fails.
+     */
+    suspend fun resetDemoData(): Boolean
 }

--- a/app/src/main/java/app/example/data/repository/EmailRepositoryImpl.kt
+++ b/app/src/main/java/app/example/data/repository/EmailRepositoryImpl.kt
@@ -160,4 +160,18 @@ class EmailRepositoryImpl
             _updates.tryEmit(Unit)
             return updatedEmail
         }
+
+        /**
+         * Triggers a system data reset on the server and clears local caches.
+         */
+        override suspend fun resetDemoData(): Boolean {
+            val response = apiService.resetSystemData()
+            if (response.success) {
+                cachedEmails = null
+                cachedDraftEmails = null
+                cachedSentEmails = null
+                _updates.tryEmit(Unit)
+            }
+            return response.success
+        }
     }

--- a/app/src/test/java/app/example/circuit/FakeEmailRepository.kt
+++ b/app/src/test/java/app/example/circuit/FakeEmailRepository.kt
@@ -70,6 +70,8 @@ class FakeEmailRepository(
         val newReadState = isRead ?: !target.isRead
         return target.copy(isRead = newReadState)
     }
+
+    override suspend fun resetDemoData(): Boolean = true
 }
 
 /** Convenience factory for creating [Email] instances in tests. */

--- a/app/src/test/java/app/example/circuit/InboxPresenterTest.kt
+++ b/app/src/test/java/app/example/circuit/InboxPresenterTest.kt
@@ -255,6 +255,27 @@ class InboxPresenterTest {
                 cancelAndIgnoreRemainingEvents()
             }
         }
+
+    @Test
+    fun `present - OnResetDemoData event triggers repository system reset`() =
+        runTest {
+            val presenter =
+                InboxPresenter(
+                    navigator = fakeNavigator,
+                    emailRepository = FakeEmailRepository(inboxEmails = listOf(testEmail())),
+                    appVersionService = fakeVersionService,
+                    networkMonitor = fakeNetworkMonitor,
+                    userPreferencesRepository = fakeUserPreferencesRepository,
+                )
+
+            presenter.test {
+                assertEquals(InboxScreen.State.Loading, awaitItem())
+                val successState = awaitItem() as InboxScreen.State.Success
+
+                successState.eventSink(InboxScreen.Event.OnResetDemoData)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 }
 
 class FakeNetworkMonitor(


### PR DESCRIPTION
Integrates POST /api/system/reset endpoint into EmailApiService & EmailRepository, and adds a Reset Demo Emails button to the App Information bottom sheet overlay.